### PR TITLE
Update `quarto-render.yml` to work with new version names.

### DIFF
--- a/.github/workflows/quarto-render.yml
+++ b/.github/workflows/quarto-render.yml
@@ -19,7 +19,8 @@ jobs:
         grep "browser_download_url.*deb" | 
         cut -d '"' -f 4 |
         wget -i -
-        sudo dpkg -i quarto-0.1-amd64.deb
+
+        sudo dpkg -i $(ls quarto*deb)
 
     - uses: actions/setup-python@v2
 


### PR DESCRIPTION
The way quarto releases are numbered has changed and this leads to `quarto-render.yml` to break. This commit fixes that by changing the way `quarto-render.yml` finds the downloaded quarto release. 