### PR TITLE
Update to latest `quarto-render` action

### DIFF
--- a/.github/workflows/quarto-render.yml
+++ b/.github/workflows/quarto-render.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: "Install Quarto and render project"
-      uses: pommevilla/quarto-render@v0.2.0-alpha
+      uses: pommevilla/quarto-render@v0.3.0
 
     - name: "Deploy to gh-pages"
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Thank you for this action - it was very helpful for me setting up my own.

This PR is a tiny change, simply because the latest version of the `quarto-render` action uses the latest version of quarto.