### PR TITLE
Docs/render note

### DIFF
--- a/.github/workflows/quarto-render.yml
+++ b/.github/workflows/quarto-render.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: "Install Quarto and render project"
-      uses: pommevilla/quarto-render@v0.3.0
+      uses: pommevilla/quarto-render@v0.3.1
 
     - name: "Deploy to gh-pages"
       uses: peaceiris/actions-gh-pages@v3

--- a/contributing/workflow.md
+++ b/contributing/workflow.md
@@ -95,6 +95,13 @@ From [R Packages](https://r-pkgs.org/git.html#git-commit):
 
 Here are some of Hadley Wickham's suggested [best practices](https://r-pkgs.org/git.html#commit-best-practices)
 
+:::{.callout-important}
+## You must re-render documents where code was added or changed before continuing
+If you added or made changes to any code (including changing the dataset upon which existing code relies), re-render those files individudally. See the [Quarto render](#quarto-render) section for more details. Afterwards, `git add` and `git commit` any changes to the updated `_freeze` directory before continuining on to the next step.
+
+Local re-rendering is necessary in cases where code is changed because the [workflow used to make this site](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/blob/main/.github/workflows/quarto-render.yml) assumes that all code has been pre-executed. Read more about this at [freeze section](https://quarto.org/docs/books/book-authoring.html?q=freeze#freezing) at the Quarto docs. 
+:::
+
 ### Push changes
 
 When you're ready to push changes you've made in your branch, you'll first need to connect it to github.com by pushing it "upstream" to the "origin repository" (`-u` below is short for `--set-upstream`):


### PR DESCRIPTION
I was procrastinating and noticed that [a current workflow failed](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/runs/3177519638?check_suite_focus=true) because `jsonlite` wasn't found. This is because `quarto` couldn't find the precomputed results for that document in the `_freeze` directory and is trying to execute the code at render time, but it fails since the workflow doesn't install any dependencies. 

I added a callout note in `contributing/workflow.md` that warns the reader that they need to individually render any files where code was added or changed to avoid this. This is mentioned kind of briefly through the Workflow page, but I wanted to really make it clear that this is necessary to avoid breaking the site. 

Also, I updated the quarto-render action version number while I was here. 