### PR TITLE
Update quarto-render version number

### DIFF
--- a/.github/workflows/quarto-render.yml
+++ b/.github/workflows/quarto-render.yml
@@ -27,7 +27,7 @@ jobs:
         python quarto_import.py -f assets.json
 
     - name: "Install Quarto and render project"
-      uses: pommevilla/quarto-render@v0.3.1
+      uses: pommevilla/quarto-render@v0.3.11
 
     - name: "Deploy to gh-pages"
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
I updated the `quarto-render` action to the latest (at this time) version of Quarto. The previous version of `quarto-render` used Quarto version 0.2.26, while the current version is 0.2.232 😅 