### PR TITLE
Edit and move OPeNDAP tutorial

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -98,6 +98,8 @@ website:
             text: "`earthaccess` Python library"
           - href: tutorials/fair-workflow-geoweaver-demo.ipynb
             text: "Pygeoweaver Workflow Demo"
+          - text: "OPeNDAP Access" 
+            href: how-tos/working-locally/Earthdata_Cloud__Data_Access_OPeNDAP_Example.ipynb
       - section: workshops/index.qmd
         contents:
           - href: workshops/setup.md
@@ -112,8 +114,6 @@ website:
             text: "Direct Access & Harmony Workflow"
           - href: examples/USGS_Landsat/Landsat_C2_Search_Access.ipynb
             text: "Search & Access USGS Landsat Cloud"  
-          - text: "OPeNDAP Access" 
-            href: how-tos/working-locally/Earthdata_Cloud__Data_Access_OPeNDAP_Example.ipynb
           - examples/ORNL/Data_Access__Direct_S3_Access__ORNL_DAYMET.ipynb
           - external/cof-zarr-reformat.ipynb
           - external/zarr-eosdis-store.ipynb

--- a/how-tos/working-locally/Earthdata_Cloud__Data_Access_OPeNDAP_Example.ipynb
+++ b/how-tos/working-locally/Earthdata_Cloud__Data_Access_OPeNDAP_Example.ipynb
@@ -26,10 +26,11 @@
     "### Prerequisites\n",
     "\n",
     "- A valid [Earthdata Login account](https://urs.earthdata.nasa.gov/)\n",
+    "    - Generation of the `.netrc` and `.dodsrc` files (both files will be generated in this notebook)\n",
     "- Python 3.7 or higher\n",
     "- [Xarray](https://docs.xarray.dev/en/stable/)\n",
     "- [netcdf4-python](https://unidata.github.io/netcdf4-python/) \n",
-    "- netcdf-c version == 4.9.0\n",
+    "- netcdf-c version == 4.8.1, 4.9.0, or >=4.9.3\n",
     "    - To check the version of your library, call the following function: <code>nc4.getlibversion()</code>"
    ]
   },
@@ -63,7 +64,11 @@
     "import earthaccess\n",
     "import datetime as dt\n",
     "import pprint\n",
-    "import netCDF4 as nc4"
+    "import netCDF4 as nc4\n",
+    "from subprocess import Popen\n",
+    "import platform\n",
+    "import os\n",
+    "import shutil"
    ]
   },
   {
@@ -72,7 +77,9 @@
    "id": "0472ce62",
    "metadata": {},
    "source": [
-    "## 2. Create EDL files using the <code>earthaccess</code> Python library"
+    "## 2. Create EDL files using the <code>earthaccess</code> Python library\n",
+    "\n",
+    "First, pass your Earthdata credentials to the `earthaccess` library to create the `.netrc` file:"
    ]
   },
   {
@@ -86,7 +93,7 @@
      "output_type": "stream",
      "text": [
       "You're now authenticated with NASA Earthdata Login\n",
-      "Using token with expiration date: 05/12/2023\n",
+      "Using token with expiration date: 07/14/2023\n",
       "Using user provided credentials for EDL\n",
       "Persisting credentials to .netrc\n"
      ]
@@ -94,6 +101,39 @@
    ],
    "source": [
     "auth = earthaccess.login(strategy=\"interactive\", persist=True) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b230ca6",
+   "metadata": {},
+   "source": [
+    "Next, run the following code to generate the `.dodsrc` file, if it is not already present:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01213c40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "homeDir = os.path.expanduser(\"~\") + os.sep\n",
+    "\n",
+    "with open(homeDir + '.dodsrc', 'w') as file:\n",
+    "    file.write('HTTP.COOKIEJAR={}.urs_cookies\\n'.format(homeDir))\n",
+    "    file.write('HTTP.NETRC={}.netrc'.format(homeDir))\n",
+    "    file.close()\n",
+    "\n",
+    "print('Saved .dodsrc to:', homeDir)\n",
+    "\n",
+    "# Set appropriate permissions for Linux/macOS\n",
+    "if platform.system() != \"Windows\":\n",
+    "    Popen('chmod og-rw ~/.netrc', shell=True)\n",
+    "else:\n",
+    "    # Copy dodsrc to working directory in Windows  \n",
+    "    shutil.copy2(homeDir + '.dodsrc', os.getcwd())\n",
+    "    print('Copied .dodsrc to:', os.getcwd())"
    ]
   },
   {
@@ -118,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "47d44059",
    "metadata": {},
    "outputs": [
@@ -151,16 +191,12 @@
     "## 4. Searching for Daymet Files using the CMR Search API\n",
     "Daymet daily data files (or granules) are in netCDF4 format, and each file has one year's worth of data. Data files are organized by variables (each for dayl, prcp, tmin, tmax, srad, swe, vp) and regions (each for us, pr, hi).  Daymet filenames can be used to identify the files from continental North America (`*_na_*.nc`). The files from Puerto Rico and Hawaii are named as (`*_pr_*.nc`) and (`*_hi_*.nc`) respectively.\n",
     "\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "https://cmr.earthdata.nasa.gov/search/granules\n",
-    "</div>\n",
-    "\n",
     "Below, we create appropriately formatted strings for our temporal range:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "a0f82e62",
    "metadata": {},
    "outputs": [
@@ -195,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "f37d9918",
    "metadata": {},
    "outputs": [
@@ -210,7 +246,7 @@
        " 'https://opendap.earthdata.nasa.gov/collections/C2532426483-ORNL_CLOUD/granules/Daymet_Daily_V4R1.daymet_v4_daily_na_tmax_2011.nc']"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -258,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "a4285143",
    "metadata": {},
    "outputs": [
@@ -279,7 +315,7 @@
        "    groups: "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -305,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "9c81ea70",
    "metadata": {},
    "outputs": [
@@ -689,19 +725,19 @@
        "    build_dmrpp_metadata.bes:            3.20.13-563\n",
        "    build_dmrpp_metadata.libdap:         libdap-3.20.11-193\n",
        "    build_dmrpp_metadata.configuration:  \\n# TheBESKeys::get_as_config()\\nAll...\n",
-       "    build_dmrpp_metadata.invocation:     build_dmrpp -c /tmp/bes_conf_p6Fo -f...</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-88cf9b93-cbd0-4364-ad51-9c95482cf1a6' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-88cf9b93-cbd0-4364-ad51-9c95482cf1a6' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 584</li><li><span class='xr-has-index'>x</span>: 284</li><li><span class='xr-has-index'>time</span>: 365</li><li><span>nv</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-0bf0b868-3a5a-40e7-82b7-ee2cbd4332b1' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0bf0b868-3a5a-40e7-82b7-ee2cbd4332b1' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-3.9e+04 -4e+04 ... -6.22e+05</div><input id='attrs-11bde1b3-2728-4580-b04b-bf82c51ef1bc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-11bde1b3-2728-4580-b04b-bf82c51ef1bc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e512a467-cdec-4e19-be7e-29da3adc2afa' class='xr-var-data-in' type='checkbox'><label for='data-e512a467-cdec-4e19-be7e-29da3adc2afa' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([ -39000.,  -40000.,  -41000., ..., -620000., -621000., -622000.],\n",
-       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-a6fcb32a-753b-42f5-bffd-1e6169535bbc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a6fcb32a-753b-42f5-bffd-1e6169535bbc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6449a22f-52cd-48d0-a38c-af9cfb8e515b' class='xr-var-data-in' type='checkbox'><label for='data-6449a22f-52cd-48d0-a38c-af9cfb8e515b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude coordinate</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lat</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-7a12c46f-4b45-4a81-bcdf-2c43695fc411' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7a12c46f-4b45-4a81-bcdf-2c43695fc411' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-836c33a9-9a64-4d32-8e23-c8591e9fbac5' class='xr-var-data-in' type='checkbox'><label for='data-836c33a9-9a64-4d32-8e23-c8591e9fbac5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude coordinate</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2010-01-01T12:00:00 ... 2010-12-...</div><input id='attrs-206f7301-1e5a-4903-8bb0-a0c1ba87dca7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-206f7301-1e5a-4903-8bb0-a0c1ba87dca7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-15e4b82e-0008-4e11-9ce3-3ce56a0175a5' class='xr-var-data-in' type='checkbox'><label for='data-15e4b82e-0008-4e11-9ce3-3ce56a0175a5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>long_name :</span></dt><dd>24-hour day based on local time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2010-01-01T12:00:00.000000000&#x27;, &#x27;2010-01-02T12:00:00.000000000&#x27;,\n",
+       "    build_dmrpp_metadata.invocation:     build_dmrpp -c /tmp/bes_conf_p6Fo -f...</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-c6d23f4d-5aaa-4b3e-88d8-8554c2203fb3' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-c6d23f4d-5aaa-4b3e-88d8-8554c2203fb3' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 584</li><li><span class='xr-has-index'>x</span>: 284</li><li><span class='xr-has-index'>time</span>: 365</li><li><span>nv</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-318e8035-7f7f-4018-b9e6-f34fc92228fa' class='xr-section-summary-in' type='checkbox'  checked><label for='section-318e8035-7f7f-4018-b9e6-f34fc92228fa' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-3.9e+04 -4e+04 ... -6.22e+05</div><input id='attrs-00f35e0c-a077-43b1-86cf-899c28aa26c6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-00f35e0c-a077-43b1-86cf-899c28aa26c6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-29edfee9-0c1d-4e7b-82fd-342c394391cf' class='xr-var-data-in' type='checkbox'><label for='data-29edfee9-0c1d-4e7b-82fd-342c394391cf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([ -39000.,  -40000.,  -41000., ..., -620000., -621000., -622000.],\n",
+       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-63bb638b-c0e1-40de-8689-aa3e1b7d6998' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-63bb638b-c0e1-40de-8689-aa3e1b7d6998' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eae4f820-1530-4add-ba44-17e5f9a88d37' class='xr-var-data-in' type='checkbox'><label for='data-eae4f820-1530-4add-ba44-17e5f9a88d37' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude coordinate</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lat</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-be63d69e-c34b-4642-a16f-882644f27545' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-be63d69e-c34b-4642-a16f-882644f27545' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-66a82940-c438-47ef-b0dc-e9248ce24a56' class='xr-var-data-in' type='checkbox'><label for='data-66a82940-c438-47ef-b0dc-e9248ce24a56' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude coordinate</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2010-01-01T12:00:00 ... 2010-12-...</div><input id='attrs-626b81d3-b2e2-4393-a46b-6948daac302d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-626b81d3-b2e2-4393-a46b-6948daac302d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-20927b21-f800-46b0-9832-e2b975be4f6d' class='xr-var-data-in' type='checkbox'><label for='data-20927b21-f800-46b0-9832-e2b975be4f6d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>long_name :</span></dt><dd>24-hour day based on local time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2010-01-01T12:00:00.000000000&#x27;, &#x27;2010-01-02T12:00:00.000000000&#x27;,\n",
        "       &#x27;2010-01-03T12:00:00.000000000&#x27;, ..., &#x27;2010-12-29T12:00:00.000000000&#x27;,\n",
        "       &#x27;2010-12-30T12:00:00.000000000&#x27;, &#x27;2010-12-31T12:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-5.802e+06 ... -5.519e+06</div><input id='attrs-181365b0-78d4-4c83-a006-941bd0d5d497' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-181365b0-78d4-4c83-a006-941bd0d5d497' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ca1534b6-c5af-45d0-97c8-db0a770d0a72' class='xr-var-data-in' type='checkbox'><label for='data-ca1534b6-c5af-45d0-97c8-db0a770d0a72' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([-5802250., -5801250., -5800250., ..., -5521250., -5520250., -5519250.],\n",
-       "      dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-5c37aa36-34a4-49f8-9ac5-28f1881bb6eb' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5c37aa36-34a4-49f8-9ac5-28f1881bb6eb' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tmax</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-585d7557-04d7-4fb4-a2db-f4fb293f378a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-585d7557-04d7-4fb4-a2db-f4fb293f378a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1b91ca28-2915-45c2-a0e1-588b4755c200' class='xr-var-data-in' type='checkbox'><label for='data-1b91ca28-2915-45c2-a0e1-588b4755c200' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>daily maximum temperature</dd><dt><span>units :</span></dt><dd>degrees C</dd><dt><span>grid_mapping :</span></dt><dd>lambert_conformal_conic</dd><dt><span>cell_methods :</span></dt><dd>area: mean time: maximum</dd></dl></div><div class='xr-var-data'><pre>[60537440 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lambert_conformal_conic</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int16</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-65f924eb-4571-4c6d-9e7d-cb09441effce' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-65f924eb-4571-4c6d-9e7d-cb09441effce' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bad879bf-a96c-47b3-9a42-c7767717916b' class='xr-var-data-in' type='checkbox'><label for='data-bad879bf-a96c-47b3-9a42-c7767717916b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping_name :</span></dt><dd>lambert_conformal_conic</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>-100.0</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>42.5</dd><dt><span>false_easting :</span></dt><dd>0.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>standard_parallel :</span></dt><dd>[25. 60.]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd></dl></div><div class='xr-var-data'><pre>array(-32767, dtype=int16)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, nv)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-470a89a0-5f5a-4408-90eb-76040abbf71b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-470a89a0-5f5a-4408-90eb-76040abbf71b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-52a3361e-444c-4f6e-a16d-80ea84aba538' class='xr-var-data-in' type='checkbox'><label for='data-52a3361e-444c-4f6e-a16d-80ea84aba538' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[&#x27;2010-01-01T00:00:00.000000000&#x27;, &#x27;2010-01-02T00:00:00.000000000&#x27;],\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-5.802e+06 ... -5.519e+06</div><input id='attrs-bc1a039c-9678-4486-a435-dd1ce2f46d81' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bc1a039c-9678-4486-a435-dd1ce2f46d81' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-35ed3d75-0067-4712-8079-424e12e87c9b' class='xr-var-data-in' type='checkbox'><label for='data-35ed3d75-0067-4712-8079-424e12e87c9b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([-5802250., -5801250., -5800250., ..., -5521250., -5520250., -5519250.],\n",
+       "      dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-f45eba4a-2b44-4142-ad9b-d7bed0db0bb2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f45eba4a-2b44-4142-ad9b-d7bed0db0bb2' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tmax</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-0d957690-cec9-4f5d-99ac-716f1adb9d4c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0d957690-cec9-4f5d-99ac-716f1adb9d4c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2cb879df-5314-4a5b-ac95-7777b595aa52' class='xr-var-data-in' type='checkbox'><label for='data-2cb879df-5314-4a5b-ac95-7777b595aa52' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>daily maximum temperature</dd><dt><span>units :</span></dt><dd>degrees C</dd><dt><span>grid_mapping :</span></dt><dd>lambert_conformal_conic</dd><dt><span>cell_methods :</span></dt><dd>area: mean time: maximum</dd></dl></div><div class='xr-var-data'><pre>[60537440 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lambert_conformal_conic</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int16</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-a04de155-2d82-46ac-9f89-d568393db42d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a04de155-2d82-46ac-9f89-d568393db42d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6d24e5cf-98fa-4d2b-bbce-ee3c30e832a9' class='xr-var-data-in' type='checkbox'><label for='data-6d24e5cf-98fa-4d2b-bbce-ee3c30e832a9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping_name :</span></dt><dd>lambert_conformal_conic</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>-100.0</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>42.5</dd><dt><span>false_easting :</span></dt><dd>0.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>standard_parallel :</span></dt><dd>[25. 60.]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd></dl></div><div class='xr-var-data'><pre>array(-32767, dtype=int16)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, nv)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-3e19f3d3-1eeb-4a31-8c30-bbb849f43258' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-3e19f3d3-1eeb-4a31-8c30-bbb849f43258' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5c0843c6-83a7-435a-8a62-013ca74eabf4' class='xr-var-data-in' type='checkbox'><label for='data-5c0843c6-83a7-435a-8a62-013ca74eabf4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[&#x27;2010-01-01T00:00:00.000000000&#x27;, &#x27;2010-01-02T00:00:00.000000000&#x27;],\n",
        "       [&#x27;2010-01-02T00:00:00.000000000&#x27;, &#x27;2010-01-03T00:00:00.000000000&#x27;],\n",
        "       [&#x27;2010-01-03T00:00:00.000000000&#x27;, &#x27;2010-01-04T00:00:00.000000000&#x27;],\n",
        "       ...,\n",
        "       [&#x27;2010-12-29T00:00:00.000000000&#x27;, &#x27;2010-12-30T00:00:00.000000000&#x27;],\n",
        "       [&#x27;2010-12-30T00:00:00.000000000&#x27;, &#x27;2010-12-31T00:00:00.000000000&#x27;],\n",
        "       [&#x27;2010-12-31T00:00:00.000000000&#x27;, &#x27;2011-01-01T00:00:00.000000000&#x27;]],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>yearday</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>int16</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-353e722b-7bfe-4251-b1fb-7c9838e36227' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-353e722b-7bfe-4251-b1fb-7c9838e36227' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5e7d5f4b-09f4-4600-86a2-932f8ec4a5a0' class='xr-var-data-in' type='checkbox'><label for='data-5e7d5f4b-09f4-4600-86a2-932f8ec4a5a0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>day of year (DOY) starting with day 1 on Januaray 1st</dd></dl></div><div class='xr-var-data'><pre>array([  1,   2,   3, ..., 363, 364, 365], dtype=int16)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-16834149-1495-4c12-99ef-3bfbfee810d8' class='xr-section-summary-in' type='checkbox'  ><label for='section-16834149-1495-4c12-99ef-3bfbfee810d8' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>start_year :</span></dt><dd>2010</dd><dt><span>source :</span></dt><dd>Daymet Software Version 4.0</dd><dt><span>Version_software :</span></dt><dd>Daymet Software Version 4.0</dd><dt><span>Version_data :</span></dt><dd>Daymet Data Version 4.0</dd><dt><span>Conventions :</span></dt><dd>CF-1.6</dd><dt><span>citation :</span></dt><dd>Please see http://daymet.ornl.gov/ for current Daymet data citation information</dd><dt><span>references :</span></dt><dd>Please see http://daymet.ornl.gov/ for current information on Daymet references</dd><dt><span>build_dmrpp_metadata.build_dmrpp :</span></dt><dd>3.20.13-563</dd><dt><span>build_dmrpp_metadata.bes :</span></dt><dd>3.20.13-563</dd><dt><span>build_dmrpp_metadata.libdap :</span></dt><dd>libdap-3.20.11-193</dd><dt><span>build_dmrpp_metadata.configuration :</span></dt><dd>\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>yearday</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>int16</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-c4db9494-7e7a-49be-9eeb-4cbfb763f630' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c4db9494-7e7a-49be-9eeb-4cbfb763f630' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b5d7e899-2a52-4e25-b1c1-d51c3cd6e845' class='xr-var-data-in' type='checkbox'><label for='data-b5d7e899-2a52-4e25-b1c1-d51c3cd6e845' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>day of year (DOY) starting with day 1 on Januaray 1st</dd></dl></div><div class='xr-var-data'><pre>array([  1,   2,   3, ..., 363, 364, 365], dtype=int16)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-481a595b-02c1-4c40-8833-c49b4b93baae' class='xr-section-summary-in' type='checkbox'  ><label for='section-481a595b-02c1-4c40-8833-c49b4b93baae' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>start_year :</span></dt><dd>2010</dd><dt><span>source :</span></dt><dd>Daymet Software Version 4.0</dd><dt><span>Version_software :</span></dt><dd>Daymet Software Version 4.0</dd><dt><span>Version_data :</span></dt><dd>Daymet Data Version 4.0</dd><dt><span>Conventions :</span></dt><dd>CF-1.6</dd><dt><span>citation :</span></dt><dd>Please see http://daymet.ornl.gov/ for current Daymet data citation information</dd><dt><span>references :</span></dt><dd>Please see http://daymet.ornl.gov/ for current information on Daymet references</dd><dt><span>build_dmrpp_metadata.build_dmrpp :</span></dt><dd>3.20.13-563</dd><dt><span>build_dmrpp_metadata.bes :</span></dt><dd>3.20.13-563</dd><dt><span>build_dmrpp_metadata.libdap :</span></dt><dd>libdap-3.20.11-193</dd><dt><span>build_dmrpp_metadata.configuration :</span></dt><dd>\n",
        "# TheBESKeys::get_as_config()\n",
        "AllowedHosts=^https?:\\/\\/\n",
        "BES.Catalog.catalog.FollowSymLinks=Yes\n",
@@ -756,7 +792,7 @@
        "    build_dmrpp_metadata.invocation:     build_dmrpp -c /tmp/bes_conf_p6Fo -f..."
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -779,22 +815,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "6b8782ab",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "syntax error, unexpected $end, expecting ';'\n",
-      "context: Error {  code = 500; message = \"ERROR: Problem encountered with BES connection. On transaction attempt:2 a PPTException was caught. Message: BES Client Failed To Start. Message: 'Could not connect to host localhost on port 10022. Connection refused (Connection refused)' \";}^\n",
-      "syntax error, unexpected $end, expecting ';'\n",
-      "context: Error {  code = 500; message = \"ERROR: Problem encountered with BES connection. On transaction attempt:2 a PPTException was caught. Message: BES Client Failed To Start. Message: 'Could not connect to host localhost on port 10022. Connection refused (Connection refused)' \";}^\n",
-      "syntax error, unexpected $end, expecting ';'\n",
-      "context: Error {  code = 500; message = \"ERROR: Problem encountered with BES connection. On transaction attempt:2 a PPTException was caught. Message: BES Client Failed To Start. Message: 'Could not connect to host localhost on port 10022. Connection refused (Connection refused)' \";}^\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -1196,7 +1220,7 @@
        "  * y        (y) float32 -3.9e+04 -4e+04 -4.1e+04 ... -6.21e+05 -6.22e+05\n",
        "    lon      (y, x) float32 ...\n",
        "    lat      (y, x) float32 ...\n",
-       "  * x        (x) float32 -5.802e+06 -5.801e+06 -5.8e+06 ... -5.52e+06 -5.519e+06</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'tmax'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 12</li><li><span class='xr-has-index'>y</span>: 584</li><li><span class='xr-has-index'>x</span>: 284</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-00fa9bcb-f9fc-4773-9a2a-6fcb3fb2b774' class='xr-array-in' type='checkbox' checked><label for='section-00fa9bcb-f9fc-4773-9a2a-6fcb3fb2b774' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[[nan, nan, nan, ..., nan, nan, nan],\n",
+       "  * x        (x) float32 -5.802e+06 -5.801e+06 -5.8e+06 ... -5.52e+06 -5.519e+06</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'tmax'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 12</li><li><span class='xr-has-index'>y</span>: 584</li><li><span class='xr-has-index'>x</span>: 284</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-05d58a24-774a-4bba-abb4-7a1daf3b74b9' class='xr-array-in' type='checkbox' checked><label for='section-05d58a24-774a-4bba-abb4-7a1daf3b74b9' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[[nan, nan, nan, ..., nan, nan, nan],\n",
        "        [nan, nan, nan, ..., nan, nan, nan],\n",
        "        [nan, nan, nan, ..., nan, nan, nan],\n",
        "        ...,\n",
@@ -1236,15 +1260,15 @@
        "        ...,\n",
        "        [nan, nan, nan, ..., nan, nan, nan],\n",
        "        [nan, nan, nan, ..., nan, nan, nan],\n",
-       "        [nan, nan, nan, ..., nan, nan, nan]]], dtype=float32)</pre></div></div></li><li class='xr-section-item'><input id='section-5d716507-49ba-46cd-89ad-5b60384c0638' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5d716507-49ba-46cd-89ad-5b60384c0638' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2010-01-31 ... 2010-12-31</div><input id='attrs-63ca6d5f-5ad6-4eff-b2ae-1d5abfcb2723' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-63ca6d5f-5ad6-4eff-b2ae-1d5abfcb2723' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ad66c45e-3302-42bd-9482-0008b3edd90d' class='xr-var-data-in' type='checkbox'><label for='data-ad66c45e-3302-42bd-9482-0008b3edd90d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2010-01-31T00:00:00.000000000&#x27;, &#x27;2010-02-28T00:00:00.000000000&#x27;,\n",
+       "        [nan, nan, nan, ..., nan, nan, nan]]], dtype=float32)</pre></div></div></li><li class='xr-section-item'><input id='section-59a45ba7-0735-4db5-ab38-20d4771ac346' class='xr-section-summary-in' type='checkbox'  checked><label for='section-59a45ba7-0735-4db5-ab38-20d4771ac346' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2010-01-31 ... 2010-12-31</div><input id='attrs-e2d13cbf-73e5-4e06-aace-1ab86f1fb99d' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e2d13cbf-73e5-4e06-aace-1ab86f1fb99d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eb6fbde4-888c-4787-acaf-b5c6817328f7' class='xr-var-data-in' type='checkbox'><label for='data-eb6fbde4-888c-4787-acaf-b5c6817328f7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2010-01-31T00:00:00.000000000&#x27;, &#x27;2010-02-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2010-03-31T00:00:00.000000000&#x27;, &#x27;2010-04-30T00:00:00.000000000&#x27;,\n",
        "       &#x27;2010-05-31T00:00:00.000000000&#x27;, &#x27;2010-06-30T00:00:00.000000000&#x27;,\n",
        "       &#x27;2010-07-31T00:00:00.000000000&#x27;, &#x27;2010-08-31T00:00:00.000000000&#x27;,\n",
        "       &#x27;2010-09-30T00:00:00.000000000&#x27;, &#x27;2010-10-31T00:00:00.000000000&#x27;,\n",
        "       &#x27;2010-11-30T00:00:00.000000000&#x27;, &#x27;2010-12-31T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-3.9e+04 -4e+04 ... -6.22e+05</div><input id='attrs-67476e6c-7070-4190-80cb-1851380f60ff' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-67476e6c-7070-4190-80cb-1851380f60ff' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-864c7871-8d9e-43f2-bd33-8799035e6c56' class='xr-var-data-in' type='checkbox'><label for='data-864c7871-8d9e-43f2-bd33-8799035e6c56' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([ -39000.,  -40000.,  -41000., ..., -620000., -621000., -622000.],\n",
-       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-f045689a-a71d-48d8-b989-dd50d35ee8b9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f045689a-a71d-48d8-b989-dd50d35ee8b9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d3c236e0-92c3-4bac-b915-a1cc350ae033' class='xr-var-data-in' type='checkbox'><label for='data-d3c236e0-92c3-4bac-b915-a1cc350ae033' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude coordinate</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lat</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-5fa1ffce-c40c-45e3-9130-c017db26ff4b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5fa1ffce-c40c-45e3-9130-c017db26ff4b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c580ad6e-9a85-49b0-99a2-48d2bb25a35e' class='xr-var-data-in' type='checkbox'><label for='data-c580ad6e-9a85-49b0-99a2-48d2bb25a35e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude coordinate</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-5.802e+06 ... -5.519e+06</div><input id='attrs-8251e6e3-31c2-447a-9854-6ec9f001e3c4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8251e6e3-31c2-447a-9854-6ec9f001e3c4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6798b265-b7db-4c4f-bfea-ec4b8602d1ec' class='xr-var-data-in' type='checkbox'><label for='data-6798b265-b7db-4c4f-bfea-ec4b8602d1ec' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([-5802250., -5801250., -5800250., ..., -5521250., -5520250., -5519250.],\n",
-       "      dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-621fc531-8c3e-4193-bd90-fb82ed4f3bd4' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-621fc531-8c3e-4193-bd90-fb82ed4f3bd4' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-3.9e+04 -4e+04 ... -6.22e+05</div><input id='attrs-5073a99f-d4fb-4cbc-9d4b-4354740c6e77' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5073a99f-d4fb-4cbc-9d4b-4354740c6e77' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0eb45cf7-a4c6-4632-92c9-525950c3c8e8' class='xr-var-data-in' type='checkbox'><label for='data-0eb45cf7-a4c6-4632-92c9-525950c3c8e8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([ -39000.,  -40000.,  -41000., ..., -620000., -621000., -622000.],\n",
+       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-f9c8bad2-2e5b-486a-bc04-942ecc50ee8b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f9c8bad2-2e5b-486a-bc04-942ecc50ee8b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3bdc5772-16ad-4773-a51a-c0ccfbc0028c' class='xr-var-data-in' type='checkbox'><label for='data-3bdc5772-16ad-4773-a51a-c0ccfbc0028c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude coordinate</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lat</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-625fbff9-9974-4ab1-ac0c-d34571b9e3bb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-625fbff9-9974-4ab1-ac0c-d34571b9e3bb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b62bdacf-8268-4b01-8f32-dfaf8e05488e' class='xr-var-data-in' type='checkbox'><label for='data-b62bdacf-8268-4b01-8f32-dfaf8e05488e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude coordinate</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-5.802e+06 ... -5.519e+06</div><input id='attrs-ae95d5ed-791f-46f2-bf7a-2b4af720e6ac' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ae95d5ed-791f-46f2-bf7a-2b4af720e6ac' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-64b7ed99-a0d8-4959-874b-52ad7929d9eb' class='xr-var-data-in' type='checkbox'><label for='data-64b7ed99-a0d8-4959-874b-52ad7929d9eb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([-5802250., -5801250., -5800250., ..., -5521250., -5520250., -5519250.],\n",
+       "      dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-eb5056a4-a013-41d3-8ad3-f0ae64bca88a' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-eb5056a4-a013-41d3-8ad3-f0ae64bca88a' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'tmax' (time: 12, y: 584, x: 284)>\n",
@@ -1297,7 +1321,7 @@
        "  * x        (x) float32 -5.802e+06 -5.801e+06 -5.8e+06 ... -5.52e+06 -5.519e+06"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1310,25 +1334,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "b467bbe8",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "syntax error, unexpected $end, expecting ';'\n",
-      "context: Error {  code = 500; message = \"ERROR: Problem encountered with BES connection. On transaction attempt:2 a PPTException was caught. Message: BES Client Failed To Start. Message: 'Could not connect to host localhost on port 10022. Connection refused (Connection refused)' \";}^\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7fc343bf1880>"
+       "<matplotlib.collections.QuadMesh at 0x7fdaba88de50>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1347,6 +1363,14 @@
     "# Xarray plotting\n",
     "monthly_tmax_mean[6,:,:].plot()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b38876d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Change markdown to specify the libnetcdf version, and move back to the "tutorials" directory, since the `BES Connection` errors are no longer occurring.