### PR TITLE
Include Cloud Primer link

### DIFF
--- a/environment-setup/index.qmd
+++ b/environment-setup/index.qmd
@@ -44,3 +44,5 @@ Setting up corn involves two steps: (1) Downloading the environment.yml, and (2)
 *more coming soon*
 
 TODO - from local machine how will you connect to AWS?
+
+[Cloud Primer for Amazon Web Services](https://www.earthdata.nasa.gov/learn/webinars-and-tutorials/cloud-primer-amazon-web-services) from NASA EOSDIS


### PR DESCRIPTION
Added at the bottom of the Cloud Environment Setup page to make sure we don't forget to include it later while beefing up this page