### PR TITLE
Resolves #295

### DIFF
--- a/how-tos/access-data/access-cloud-python.ipynb
+++ b/how-tos/access-data/access-cloud-python.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "tags": []
    },
@@ -36,21 +36,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "You're now authenticated with NASA Earthdata Login\n",
-      "Using token with expiration date: 10/30/2023\n",
-      "Using .netrc file for EDL\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Authentication with Earthdata Login\n",
     "auth = earthaccess.login(strategy=\"netrc\")"
@@ -58,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "tags": []
    },
@@ -75,7 +65,7 @@
     "#Access land ice height from ATLAS/ICESat-2 V005 (10.5067/ATLAS/ATL06.005), searching for data over western Greenland coast over two weeks in July 2022. The data are provided as HDF5 granules (files) that span about 1/14th of an orbit.\n",
     "\n",
     "results = earthaccess.search_data(short_name=\"ATL06\",\n",
-    "                                  version=\"005\",\n",
+    "                                  version=\"006\",\n",
     "                                  cloud_hosted=True,\n",
     "                                  temporal = (\"2022-07-17\",\"2022-07-31\"),\n",
     "                                  bounding_box = (-51.96423,68.10554,-48.71969,70.70529))"
@@ -1020,7 +1010,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changed version from 005 to 006 for the data access in the cell below #Access land ice height from ATLAS/ICESat-2 V005 (10.5067/ATLAS/ATL06.005), searching for data over western Greenland coast over two weeks in July 2022. The data are provided as HDF5 granules (files) that span about 1/14th of an orbit.
