### PR TITLE
Update OPeNDAP tutorial with instructions for new kernel

### DIFF
--- a/tutorials/Earthdata_Cloud__Data_Access_OPeNDAP_Example.ipynb
+++ b/tutorials/Earthdata_Cloud__Data_Access_OPeNDAP_Example.ipynb
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "sacred-quantum",
    "metadata": {},
    "outputs": [],
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "991bf70a",
    "metadata": {},
    "outputs": [],
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "01213c40",
    "metadata": {},
    "outputs": [
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "47d44059",
    "metadata": {},
    "outputs": [
@@ -195,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "a0f82e62",
    "metadata": {},
    "outputs": [
@@ -230,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "f37d9918",
    "metadata": {},
    "outputs": [
@@ -245,7 +245,7 @@
        " 'https://opendap.earthdata.nasa.gov/collections/C2532426483-ORNL_CLOUD/granules/Daymet_Daily_V4R1.daymet_v4_daily_na_tmax_2011.nc']"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -293,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "a4285143",
    "metadata": {},
    "outputs": [
@@ -314,7 +314,7 @@
        "    groups: "
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -340,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "9c81ea70",
    "metadata": {},
    "outputs": [
@@ -736,17 +736,17 @@
        "    build_dmrpp_metadata.bes:            3.20.13-563\n",
        "    build_dmrpp_metadata.libdap:         libdap-3.20.11-193\n",
        "    build_dmrpp_metadata.configuration:  \\n# TheBESKeys::get_as_config()\\nAll...\n",
-       "    build_dmrpp_metadata.invocation:     build_dmrpp -c /tmp/bes_conf_p6Fo -f...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-6d505706-8d9c-43d9-bec3-15456757a284' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-6d505706-8d9c-43d9-bec3-15456757a284' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 584</li><li><span class='xr-has-index'>x</span>: 284</li><li><span class='xr-has-index'>time</span>: 365</li><li><span>nv</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-516b56c4-78ba-4f6e-af3d-b2d3f99e932c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-516b56c4-78ba-4f6e-af3d-b2d3f99e932c' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-3.9e+04 -4e+04 ... -6.22e+05</div><input id='attrs-20d93302-0c36-48d0-b1eb-b63e91e912e4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-20d93302-0c36-48d0-b1eb-b63e91e912e4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b196b9a9-1bfc-44a9-8f28-05ec8bf2d070' class='xr-var-data-in' type='checkbox'><label for='data-b196b9a9-1bfc-44a9-8f28-05ec8bf2d070' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([ -39000.,  -40000.,  -41000., ..., -620000., -621000., -622000.],\n",
-       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-9af6007f-c7bd-480a-a7c4-ff809c65bb22' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9af6007f-c7bd-480a-a7c4-ff809c65bb22' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-44c6ddc5-963b-4fb8-b252-08c961dbaa35' class='xr-var-data-in' type='checkbox'><label for='data-44c6ddc5-963b-4fb8-b252-08c961dbaa35' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude coordinate</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lat</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-d00a55ca-c388-45f4-b264-b50f560bc7e6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d00a55ca-c388-45f4-b264-b50f560bc7e6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6af0d7a6-f990-4437-948d-66a9c19c3c72' class='xr-var-data-in' type='checkbox'><label for='data-6af0d7a6-f990-4437-948d-66a9c19c3c72' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude coordinate</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2010-01-01T12:00:00 ... 2010-12-...</div><input id='attrs-e5e90728-a8b1-4605-bd50-8a7b1e691d59' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e5e90728-a8b1-4605-bd50-8a7b1e691d59' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0af0a3a2-2eb6-4c3d-ba89-e1f2b18df6fd' class='xr-var-data-in' type='checkbox'><label for='data-0af0a3a2-2eb6-4c3d-ba89-e1f2b18df6fd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>long_name :</span></dt><dd>24-hour day based on local time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2010-01-01T12:00:00.000000000&#x27;, &#x27;2010-01-02T12:00:00.000000000&#x27;,\n",
+       "    build_dmrpp_metadata.invocation:     build_dmrpp -c /tmp/bes_conf_p6Fo -f...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-3749d1c5-75d7-4bc8-895a-36a8af205b3f' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-3749d1c5-75d7-4bc8-895a-36a8af205b3f' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 584</li><li><span class='xr-has-index'>x</span>: 284</li><li><span class='xr-has-index'>time</span>: 365</li><li><span>nv</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-0911dc7c-cc09-453b-869b-ccdc5c0fbc2c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0911dc7c-cc09-453b-869b-ccdc5c0fbc2c' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-3.9e+04 -4e+04 ... -6.22e+05</div><input id='attrs-fa7a2c69-3e6e-4dbc-a023-8ad342885a3e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fa7a2c69-3e6e-4dbc-a023-8ad342885a3e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f10f18cf-ca43-4d57-9ffb-6362018aef36' class='xr-var-data-in' type='checkbox'><label for='data-f10f18cf-ca43-4d57-9ffb-6362018aef36' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([ -39000.,  -40000.,  -41000., ..., -620000., -621000., -622000.],\n",
+       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-9c84f524-51bd-40a7-aa0c-8e50e00e05af' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9c84f524-51bd-40a7-aa0c-8e50e00e05af' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0e26415b-cdb6-4707-a739-31dcc73a2ee5' class='xr-var-data-in' type='checkbox'><label for='data-0e26415b-cdb6-4707-a739-31dcc73a2ee5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude coordinate</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lat</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-d684791e-95ca-4a89-be9a-aa4ab0023dde' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d684791e-95ca-4a89-be9a-aa4ab0023dde' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0b156d75-3df9-40a5-8d0c-fd406123cab3' class='xr-var-data-in' type='checkbox'><label for='data-0b156d75-3df9-40a5-8d0c-fd406123cab3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude coordinate</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2010-01-01T12:00:00 ... 2010-12-...</div><input id='attrs-36fd5a42-cff5-4ea9-841f-86a114a2e735' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-36fd5a42-cff5-4ea9-841f-86a114a2e735' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cc23abbb-9510-40f4-8923-4b0c553d64c4' class='xr-var-data-in' type='checkbox'><label for='data-cc23abbb-9510-40f4-8923-4b0c553d64c4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>long_name :</span></dt><dd>24-hour day based on local time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2010-01-01T12:00:00.000000000&#x27;, &#x27;2010-01-02T12:00:00.000000000&#x27;,\n",
        "       &#x27;2010-01-03T12:00:00.000000000&#x27;, ..., &#x27;2010-12-29T12:00:00.000000000&#x27;,\n",
        "       &#x27;2010-12-30T12:00:00.000000000&#x27;, &#x27;2010-12-31T12:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-5.802e+06 ... -5.519e+06</div><input id='attrs-629223f4-b204-463b-930d-b35a0d704194' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-629223f4-b204-463b-930d-b35a0d704194' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3e8779b8-4ecc-40b2-b5bd-7bb582bdddda' class='xr-var-data-in' type='checkbox'><label for='data-3e8779b8-4ecc-40b2-b5bd-7bb582bdddda' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([-5802250., -5801250., -5800250., ..., -5521250., -5520250., -5519250.],\n",
-       "      dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-74764127-4ef0-4781-85c5-5898b25790ea' class='xr-section-summary-in' type='checkbox'  checked><label for='section-74764127-4ef0-4781-85c5-5898b25790ea' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tmax</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-94b817cd-40fb-46bc-a1e6-a8147aed0a95' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-94b817cd-40fb-46bc-a1e6-a8147aed0a95' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2d4ae42e-8dda-4c7a-ac36-e73fe31c8fa7' class='xr-var-data-in' type='checkbox'><label for='data-2d4ae42e-8dda-4c7a-ac36-e73fe31c8fa7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>daily maximum temperature</dd><dt><span>units :</span></dt><dd>degrees C</dd><dt><span>grid_mapping :</span></dt><dd>lambert_conformal_conic</dd><dt><span>cell_methods :</span></dt><dd>area: mean time: maximum</dd></dl></div><div class='xr-var-data'><pre>[60537440 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lambert_conformal_conic</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int16</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-05840c50-9a2a-4584-b2a4-3e62a7214774' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-05840c50-9a2a-4584-b2a4-3e62a7214774' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-927f77af-8ca3-4fbf-afe2-4c9f20713571' class='xr-var-data-in' type='checkbox'><label for='data-927f77af-8ca3-4fbf-afe2-4c9f20713571' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping_name :</span></dt><dd>lambert_conformal_conic</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>-100.0</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>42.5</dd><dt><span>false_easting :</span></dt><dd>0.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>standard_parallel :</span></dt><dd>[25. 60.]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd></dl></div><div class='xr-var-data'><pre>[1 values with dtype=int16]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, nv)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-7b709fec-ad81-4d1a-97c4-f913404cf4ca' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7b709fec-ad81-4d1a-97c4-f913404cf4ca' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-27bd9ebe-4bca-4bfe-bcb4-298c4f6dc2d8' class='xr-var-data-in' type='checkbox'><label for='data-27bd9ebe-4bca-4bfe-bcb4-298c4f6dc2d8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>[730 values with dtype=datetime64[ns]]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>yearday</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>int16</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-7cabfc13-3a76-4be7-8ce3-161ca6e4a55e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7cabfc13-3a76-4be7-8ce3-161ca6e4a55e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5fdb635f-f403-49ce-8207-dae63d81009c' class='xr-var-data-in' type='checkbox'><label for='data-5fdb635f-f403-49ce-8207-dae63d81009c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>day of year (DOY) starting with day 1 on Januaray 1st</dd></dl></div><div class='xr-var-data'><pre>[365 values with dtype=int16]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-7a4fcd71-95c9-4953-aae0-e155b42dd8fb' class='xr-section-summary-in' type='checkbox'  ><label for='section-7a4fcd71-95c9-4953-aae0-e155b42dd8fb' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-0e1ec350-709d-49b7-8aee-b071a5c44ff4' class='xr-index-data-in' type='checkbox'/><label for='index-0e1ec350-709d-49b7-8aee-b071a5c44ff4' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ -39000.0,  -40000.0,  -41000.0,  -42000.0,  -43000.0,  -44000.0,\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-5.802e+06 ... -5.519e+06</div><input id='attrs-5c129b74-224e-47a3-95e7-f983efb87028' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5c129b74-224e-47a3-95e7-f983efb87028' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2a92ba07-c4e3-45ba-baad-9bf8d53744b8' class='xr-var-data-in' type='checkbox'><label for='data-2a92ba07-c4e3-45ba-baad-9bf8d53744b8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([-5802250., -5801250., -5800250., ..., -5521250., -5520250., -5519250.],\n",
+       "      dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-f4458106-a1e1-448f-9903-84e52c89ef05' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f4458106-a1e1-448f-9903-84e52c89ef05' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tmax</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-4d93bfc3-9105-49d9-bbb0-7ed856028543' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4d93bfc3-9105-49d9-bbb0-7ed856028543' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ec5438ee-f322-4b58-aaa3-c26190b25634' class='xr-var-data-in' type='checkbox'><label for='data-ec5438ee-f322-4b58-aaa3-c26190b25634' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>daily maximum temperature</dd><dt><span>units :</span></dt><dd>degrees C</dd><dt><span>grid_mapping :</span></dt><dd>lambert_conformal_conic</dd><dt><span>cell_methods :</span></dt><dd>area: mean time: maximum</dd></dl></div><div class='xr-var-data'><pre>[60537440 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lambert_conformal_conic</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int16</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-b42f83ab-8322-4351-b3b7-f27a54074f07' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b42f83ab-8322-4351-b3b7-f27a54074f07' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fe958092-2709-45fb-b5a5-64d0e6ab3265' class='xr-var-data-in' type='checkbox'><label for='data-fe958092-2709-45fb-b5a5-64d0e6ab3265' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping_name :</span></dt><dd>lambert_conformal_conic</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>-100.0</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>42.5</dd><dt><span>false_easting :</span></dt><dd>0.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>standard_parallel :</span></dt><dd>[25. 60.]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd></dl></div><div class='xr-var-data'><pre>[1 values with dtype=int16]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, nv)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-f9d39c8c-fdbc-41cc-a20b-4cf5aa6fa2fd' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-f9d39c8c-fdbc-41cc-a20b-4cf5aa6fa2fd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fd0d3476-fc08-444a-be0b-762f4cb328bb' class='xr-var-data-in' type='checkbox'><label for='data-fd0d3476-fc08-444a-be0b-762f4cb328bb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>[730 values with dtype=datetime64[ns]]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>yearday</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>int16</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-9fdbe7e2-e045-478f-b0aa-2bab9034aad2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9fdbe7e2-e045-478f-b0aa-2bab9034aad2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6a2004a0-7548-4b96-bfbf-8d919c7e2c3a' class='xr-var-data-in' type='checkbox'><label for='data-6a2004a0-7548-4b96-bfbf-8d919c7e2c3a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>day of year (DOY) starting with day 1 on Januaray 1st</dd></dl></div><div class='xr-var-data'><pre>[365 values with dtype=int16]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-b97c7a55-b93e-47e2-9f9b-0fa98a402fca' class='xr-section-summary-in' type='checkbox'  ><label for='section-b97c7a55-b93e-47e2-9f9b-0fa98a402fca' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-6e66f81c-8574-4d2a-8018-0506f8efdc4a' class='xr-index-data-in' type='checkbox'/><label for='index-6e66f81c-8574-4d2a-8018-0506f8efdc4a' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ -39000.0,  -40000.0,  -41000.0,  -42000.0,  -43000.0,  -44000.0,\n",
        "        -45000.0,  -46000.0,  -47000.0,  -48000.0,\n",
        "       ...\n",
        "       -613000.0, -614000.0, -615000.0, -616000.0, -617000.0, -618000.0,\n",
        "       -619000.0, -620000.0, -621000.0, -622000.0],\n",
-       "      dtype=&#x27;float32&#x27;, name=&#x27;y&#x27;, length=584))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-24e520c4-c773-4521-9329-79df6676d285' class='xr-index-data-in' type='checkbox'/><label for='index-24e520c4-c773-4521-9329-79df6676d285' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2010-01-01 12:00:00&#x27;, &#x27;2010-01-02 12:00:00&#x27;,\n",
+       "      dtype=&#x27;float32&#x27;, name=&#x27;y&#x27;, length=584))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-7a050266-2555-4fbc-b78a-46394d631192' class='xr-index-data-in' type='checkbox'/><label for='index-7a050266-2555-4fbc-b78a-46394d631192' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2010-01-01 12:00:00&#x27;, &#x27;2010-01-02 12:00:00&#x27;,\n",
        "               &#x27;2010-01-03 12:00:00&#x27;, &#x27;2010-01-04 12:00:00&#x27;,\n",
        "               &#x27;2010-01-05 12:00:00&#x27;, &#x27;2010-01-06 12:00:00&#x27;,\n",
        "               &#x27;2010-01-07 12:00:00&#x27;, &#x27;2010-01-08 12:00:00&#x27;,\n",
@@ -757,12 +757,12 @@
        "               &#x27;2010-12-26 12:00:00&#x27;, &#x27;2010-12-27 12:00:00&#x27;,\n",
        "               &#x27;2010-12-28 12:00:00&#x27;, &#x27;2010-12-29 12:00:00&#x27;,\n",
        "               &#x27;2010-12-30 12:00:00&#x27;, &#x27;2010-12-31 12:00:00&#x27;],\n",
-       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=365, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-01f5f7f1-618f-4a94-929c-30bfe6880c37' class='xr-index-data-in' type='checkbox'/><label for='index-01f5f7f1-618f-4a94-929c-30bfe6880c37' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([-5802250.0, -5801250.0, -5800250.0, -5799250.0, -5798250.0, -5797250.0,\n",
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=365, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-c9d131f4-12ba-43a5-9ded-9aa44df72d48' class='xr-index-data-in' type='checkbox'/><label for='index-c9d131f4-12ba-43a5-9ded-9aa44df72d48' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([-5802250.0, -5801250.0, -5800250.0, -5799250.0, -5798250.0, -5797250.0,\n",
        "       -5796250.0, -5795250.0, -5794250.0, -5793250.0,\n",
        "       ...\n",
        "       -5528250.0, -5527250.0, -5526250.0, -5525250.0, -5524250.0, -5523250.0,\n",
        "       -5522250.0, -5521250.0, -5520250.0, -5519250.0],\n",
-       "      dtype=&#x27;float32&#x27;, name=&#x27;x&#x27;, length=284))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-429e37a3-0555-4937-8b4a-3cbd8fefe5d4' class='xr-section-summary-in' type='checkbox'  ><label for='section-429e37a3-0555-4937-8b4a-3cbd8fefe5d4' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>start_year :</span></dt><dd>2010</dd><dt><span>source :</span></dt><dd>Daymet Software Version 4.0</dd><dt><span>Version_software :</span></dt><dd>Daymet Software Version 4.0</dd><dt><span>Version_data :</span></dt><dd>Daymet Data Version 4.0</dd><dt><span>Conventions :</span></dt><dd>CF-1.6</dd><dt><span>citation :</span></dt><dd>Please see http://daymet.ornl.gov/ for current Daymet data citation information</dd><dt><span>references :</span></dt><dd>Please see http://daymet.ornl.gov/ for current information on Daymet references</dd><dt><span>build_dmrpp_metadata.build_dmrpp :</span></dt><dd>3.20.13-563</dd><dt><span>build_dmrpp_metadata.bes :</span></dt><dd>3.20.13-563</dd><dt><span>build_dmrpp_metadata.libdap :</span></dt><dd>libdap-3.20.11-193</dd><dt><span>build_dmrpp_metadata.configuration :</span></dt><dd>\n",
+       "      dtype=&#x27;float32&#x27;, name=&#x27;x&#x27;, length=284))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-3f2cb41b-b973-4ccf-9c38-70bef7d33fe6' class='xr-section-summary-in' type='checkbox'  ><label for='section-3f2cb41b-b973-4ccf-9c38-70bef7d33fe6' class='xr-section-summary' >Attributes: <span>(12)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>start_year :</span></dt><dd>2010</dd><dt><span>source :</span></dt><dd>Daymet Software Version 4.0</dd><dt><span>Version_software :</span></dt><dd>Daymet Software Version 4.0</dd><dt><span>Version_data :</span></dt><dd>Daymet Data Version 4.0</dd><dt><span>Conventions :</span></dt><dd>CF-1.6</dd><dt><span>citation :</span></dt><dd>Please see http://daymet.ornl.gov/ for current Daymet data citation information</dd><dt><span>references :</span></dt><dd>Please see http://daymet.ornl.gov/ for current information on Daymet references</dd><dt><span>build_dmrpp_metadata.build_dmrpp :</span></dt><dd>3.20.13-563</dd><dt><span>build_dmrpp_metadata.bes :</span></dt><dd>3.20.13-563</dd><dt><span>build_dmrpp_metadata.libdap :</span></dt><dd>libdap-3.20.11-193</dd><dt><span>build_dmrpp_metadata.configuration :</span></dt><dd>\n",
        "# TheBESKeys::get_as_config()\n",
        "AllowedHosts=^https?:\\/\\/\n",
        "BES.Catalog.catalog.FollowSymLinks=Yes\n",
@@ -817,7 +817,7 @@
        "    build_dmrpp_metadata.invocation:     build_dmrpp -c /tmp/bes_conf_p6Fo -f..."
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -840,142 +840,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "6b8782ab",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/srv/conda/envs/opendap/lib/python3.10/site-packages/xarray/core/groupby.py:534: FutureWarning: 'M' is deprecated and will be removed in a future version, please use 'ME' instead.\n",
-      "  index_grouper = pd.Grouper(\n",
-      "oc_open: server error retrieving url: code=? message=\"Error { \n",
-      "    code = 500;\n",
-      "    message = \"CurlUtils::process_get_redirect_http_status() - ERROR -  I tried 3 times to access:\n",
-      "    https://data.ornldaac.earthdata.nasa.gov/protected/daymet/Daymet_Daily_V4R1/data/daymet_v4_daily_hi_tmax_2010.nc\n",
-      "I was expecting to receive an HTTP redirect code and location header in the response. \n",
-      "Unfortunately this did not happen.\n",
-      "Here are the details of the most recent transaction:\n",
-      "\n",
-      "# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\n",
-      "HTTP Response Details\n",
-      "The remote service returned an HTTP status of: 502\n",
-      "Response Headers -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\n",
-      "  Content-Type: application/json\n",
-      "  Content-Length: 36\n",
-      "  Connection: keep-alive\n",
-      "  Date: Tue, 20 Feb 2024 19:11:41 GMT\n",
-      "  x-amzn-RequestId: de4142a2-1b6b-4ade-b3c5-0af46e6e9711\n",
-      "  x-amzn-ErrorType: InternalServerErrorException\n",
-      "  x-amz-apigw-id: TcvoEGRMPHcEeAA=\n",
-      "  X-Cache: Error from cloudfront\n",
-      "  Via: 1.1 89b24af8db05335e68292856e0a53668.cloudfront.net (CloudFront)\n",
-      "  X-Amz-Cf-Pop: HIO52-P2\n",
-      "  X-Amz-Cf-Id: 2Eco7UWM1IoxutckPinxxGPOym-baXRdW_vRBw1KvpT9GlfC1L4oKg==\n",
-      "  X-XSS-Protection: 1; mode=block\n",
-      "  X-Frame-Options: SAMEORIGIN\n",
-      "  X-Content-Type-Options: nosniff\n",
-      "  Strict-Transport-Security: max-age=31536000\n",
-      "# BEGIN Response Body -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\n",
-      "{\"message\": \"Internal server error\"}\n",
-      "# END Response Body   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\";\n",
-      "}\"oc_open: server error retrieving url: code=? message=\"Error { \n",
-      "    code = 500;\n",
-      "    message = \"CurlUtils::process_get_redirect_http_status() - ERROR -  I tried 3 times to access:\n",
-      "    https://data.ornldaac.earthdata.nasa.gov/protected/daymet/Daymet_Daily_V4R1/data/daymet_v4_daily_hi_tmax_2010.nc\n",
-      "I was expecting to receive an HTTP redirect code and location header in the response. \n",
-      "Unfortunately this did not happen.\n",
-      "Here are the details of the most recent transaction:\n",
-      "\n",
-      "# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\n",
-      "HTTP Response Details\n",
-      "The remote service returned an HTTP status of: 502\n",
-      "Response Headers -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\n",
-      "  Content-Type: application/json\n",
-      "  Content-Length: 36\n",
-      "  Connection: keep-alive\n",
-      "  Date: Tue, 20 Feb 2024 19:11:41 GMT\n",
-      "  x-amzn-RequestId: de4142a2-1b6b-4ade-b3c5-0af46e6e9711\n",
-      "  x-amzn-ErrorType: InternalServerErrorException\n",
-      "  x-amz-apigw-id: TcvoEGRMPHcEeAA=\n",
-      "  X-Cache: Error from cloudfront\n",
-      "  Via: 1.1 2e87eef03ab555daefa684d946e111b4.cloudfront.net (CloudFront)\n",
-      "  X-Amz-Cf-Pop: HIO52-P2\n",
-      "  X-Amz-Cf-Id: 1tmuRdTXpFIPZpcggqZRwD0G3U0REkbCcgSMjr1MyfPI9r6huYkjyQ==\n",
-      "  Age: 1\n",
-      "  X-XSS-Protection: 1; mode=block\n",
-      "  X-Frame-Options: SAMEORIGIN\n",
-      "  X-Content-Type-Options: nosniff\n",
-      "  Strict-Transport-Security: max-age=31536000\n",
-      "# BEGIN Response Body -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\n",
-      "{\"message\": \"Internal server error\"}\n",
-      "# END Response Body   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\";\n",
-      "}\"oc_open: server error retrieving url: code=? message=\"Error { \n",
-      "    code = 500;\n",
-      "    message = \"CurlUtils::process_get_redirect_http_status() - ERROR -  I tried 3 times to access:\n",
-      "    https://data.ornldaac.earthdata.nasa.gov/protected/daymet/Daymet_Daily_V4R1/data/daymet_v4_daily_hi_tmax_2010.nc\n",
-      "I was expecting to receive an HTTP redirect code and location header in the response. \n",
-      "Unfortunately this did not happen.\n",
-      "Here are the details of the most recent transaction:\n",
-      "\n",
-      "# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\n",
-      "HTTP Response Details\n",
-      "The remote service returned an HTTP status of: 502\n",
-      "Response Headers -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\n",
-      "  Content-Type: application/json\n",
-      "  Content-Length: 36\n",
-      "  Connection: keep-alive\n",
-      "  Date: Tue, 20 Feb 2024 19:11:41 GMT\n",
-      "  x-amzn-RequestId: de4142a2-1b6b-4ade-b3c5-0af46e6e9711\n",
-      "  x-amzn-ErrorType: InternalServerErrorException\n",
-      "  x-amz-apigw-id: TcvoEGRMPHcEeAA=\n",
-      "  X-Cache: Error from cloudfront\n",
-      "  Via: 1.1 44c9323c8e1b3ab3824760718cef5d00.cloudfront.net (CloudFront)\n",
-      "  X-Amz-Cf-Pop: HIO52-P2\n",
-      "  X-Amz-Cf-Id: 8gcrZb9_lOKUTaWFyTY6mV7XBWIw8k903v1elBxKxVWVB335jKJDQw==\n",
-      "  Age: 6\n",
-      "  X-XSS-Protection: 1; mode=block\n",
-      "  X-Frame-Options: SAMEORIGIN\n",
-      "  X-Content-Type-Options: nosniff\n",
-      "  Strict-Transport-Security: max-age=31536000\n",
-      "# BEGIN Response Body -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\n",
-      "{\"message\": \"Internal server error\"}\n",
-      "# END Response Body   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\";\n",
-      "}\"oc_open: server error retrieving url: code=? message=\"Error { \n",
-      "    code = 500;\n",
-      "    message = \"CurlUtils::process_get_redirect_http_status() - ERROR -  I tried 3 times to access:\n",
-      "    https://data.ornldaac.earthdata.nasa.gov/protected/daymet/Daymet_Daily_V4R1/data/daymet_v4_daily_hi_tmax_2010.nc\n",
-      "I was expecting to receive an HTTP redirect code and location header in the response. \n",
-      "Unfortunately this did not happen.\n",
-      "Here are the details of the most recent transaction:\n",
-      "\n",
-      "# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\n",
-      "HTTP Response Details\n",
-      "The remote service returned an HTTP status of: 502\n",
-      "Response Headers -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\n",
-      "  Content-Type: application/json\n",
-      "  Content-Length: 36\n",
-      "  Connection: keep-alive\n",
-      "  Date: Tue, 20 Feb 2024 19:11:41 GMT\n",
-      "  x-amzn-RequestId: de4142a2-1b6b-4ade-b3c5-0af46e6e9711\n",
-      "  x-amzn-ErrorType: InternalServerErrorException\n",
-      "  x-amz-apigw-id: TcvoEGRMPHcEeAA=\n",
-      "  X-Cache: Error from cloudfront\n",
-      "  Via: 1.1 44e3ef26e727fc044d711ef45aefcd72.cloudfront.net (CloudFront)\n",
-      "  X-Amz-Cf-Pop: HIO52-P2\n",
-      "  X-Amz-Cf-Id: kt7zwIsKSiL3cfHihQeEPUL_RG6P4GbH4_24Pe7mPM1lN6lI2xnRlw==\n",
-      "  Age: 9\n",
-      "  X-XSS-Protection: 1; mode=block\n",
-      "  X-Frame-Options: SAMEORIGIN\n",
-      "  X-Content-Type-Options: nosniff\n",
-      "  Strict-Transport-Security: max-age=31536000\n",
-      "# BEGIN Response Body -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\n",
-      "{\"message\": \"Internal server error\"}\n",
-      "# END Response Body   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --\";\n",
-      "}\""
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -1394,7 +1262,7 @@
        "    long_name:     daily maximum temperature\n",
        "    units:         degrees C\n",
        "    grid_mapping:  lambert_conformal_conic\n",
-       "    cell_methods:  area: mean time: maximum</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'tmax'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 12</li><li><span class='xr-has-index'>y</span>: 584</li><li><span class='xr-has-index'>x</span>: 284</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-fd148cd0-780b-4da4-a1e8-08ed2b1da827' class='xr-array-in' type='checkbox' checked><label for='section-fd148cd0-780b-4da4-a1e8-08ed2b1da827' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[[nan, nan, nan, ..., nan, nan, nan],\n",
+       "    cell_methods:  area: mean time: maximum</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'tmax'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 12</li><li><span class='xr-has-index'>y</span>: 584</li><li><span class='xr-has-index'>x</span>: 284</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-97d0a761-c74d-49cd-a93b-5bcc893a2f8c' class='xr-array-in' type='checkbox' checked><label for='section-97d0a761-c74d-49cd-a93b-5bcc893a2f8c' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[[nan, nan, nan, ..., nan, nan, nan],\n",
        "        [nan, nan, nan, ..., nan, nan, nan],\n",
        "        [nan, nan, nan, ..., nan, nan, nan],\n",
        "        ...,\n",
@@ -1434,28 +1302,28 @@
        "        ...,\n",
        "        [nan, nan, nan, ..., nan, nan, nan],\n",
        "        [nan, nan, nan, ..., nan, nan, nan],\n",
-       "        [nan, nan, nan, ..., nan, nan, nan]]], dtype=float32)</pre></div></div></li><li class='xr-section-item'><input id='section-fe071ca2-8a81-4394-9b7a-b1791a4b5e3f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-fe071ca2-8a81-4394-9b7a-b1791a4b5e3f' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-3.9e+04 -4e+04 ... -6.22e+05</div><input id='attrs-f2a164f1-71ce-40de-afcf-6569de0f0b8e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f2a164f1-71ce-40de-afcf-6569de0f0b8e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-af166d4a-74c9-4a12-9bb4-79fa24ea33f3' class='xr-var-data-in' type='checkbox'><label for='data-af166d4a-74c9-4a12-9bb4-79fa24ea33f3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([ -39000.,  -40000.,  -41000., ..., -620000., -621000., -622000.],\n",
-       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-9214e7c0-212c-46f3-a0a8-aa3ac5706ee3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9214e7c0-212c-46f3-a0a8-aa3ac5706ee3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bd9aeb81-815c-4087-b847-321c196a7fd3' class='xr-var-data-in' type='checkbox'><label for='data-bd9aeb81-815c-4087-b847-321c196a7fd3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude coordinate</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lat</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-6198419f-1027-4c5c-800d-03204a5ff480' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6198419f-1027-4c5c-800d-03204a5ff480' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7ac6844a-5b35-44b2-8ef3-808eef3abc98' class='xr-var-data-in' type='checkbox'><label for='data-7ac6844a-5b35-44b2-8ef3-808eef3abc98' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude coordinate</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-5.802e+06 ... -5.519e+06</div><input id='attrs-3b82978c-a8a7-45d1-92d4-942e959d1da4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3b82978c-a8a7-45d1-92d4-942e959d1da4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7cc67857-51f4-4cfc-a59e-024bf066abac' class='xr-var-data-in' type='checkbox'><label for='data-7cc67857-51f4-4cfc-a59e-024bf066abac' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([-5802250., -5801250., -5800250., ..., -5521250., -5520250., -5519250.],\n",
-       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2010-01-31 ... 2010-12-31</div><input id='attrs-c3f0fffa-884f-46e6-b1f7-e920db80bd01' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c3f0fffa-884f-46e6-b1f7-e920db80bd01' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8571f801-77ac-4c32-a54b-99f11ec9a906' class='xr-var-data-in' type='checkbox'><label for='data-8571f801-77ac-4c32-a54b-99f11ec9a906' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>long_name :</span></dt><dd>24-hour day based on local time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2010-01-31T00:00:00.000000000&#x27;, &#x27;2010-02-28T00:00:00.000000000&#x27;,\n",
+       "        [nan, nan, nan, ..., nan, nan, nan]]], dtype=float32)</pre></div></div></li><li class='xr-section-item'><input id='section-af37376a-cb5e-4c75-947b-c9227873b3c8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-af37376a-cb5e-4c75-947b-c9227873b3c8' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-3.9e+04 -4e+04 ... -6.22e+05</div><input id='attrs-395ef4b5-47aa-4897-b654-c7deb17e52ef' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-395ef4b5-47aa-4897-b654-c7deb17e52ef' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bc750f35-7c3f-4565-9388-4469062215ae' class='xr-var-data-in' type='checkbox'><label for='data-bc750f35-7c3f-4565-9388-4469062215ae' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([ -39000.,  -40000.,  -41000., ..., -620000., -621000., -622000.],\n",
+       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-eb8f5b3c-2885-42ff-9ea6-7e7d1f6825a0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eb8f5b3c-2885-42ff-9ea6-7e7d1f6825a0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8b8f5431-5edb-4695-80c6-7421a26a2094' class='xr-var-data-in' type='checkbox'><label for='data-8b8f5431-5edb-4695-80c6-7421a26a2094' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude coordinate</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lat</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-c67c920c-022e-4f1d-b03a-a9f175a43463' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c67c920c-022e-4f1d-b03a-a9f175a43463' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7eceb709-8cf6-4a5d-84ed-9f045186b259' class='xr-var-data-in' type='checkbox'><label for='data-7eceb709-8cf6-4a5d-84ed-9f045186b259' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude coordinate</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>[165856 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-5.802e+06 ... -5.519e+06</div><input id='attrs-4b71f2e3-aa6e-48ce-a7a7-f89c26c9a846' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4b71f2e3-aa6e-48ce-a7a7-f89c26c9a846' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eaadcf55-1db2-43e7-a128-b1d45ef7da0f' class='xr-var-data-in' type='checkbox'><label for='data-eaadcf55-1db2-43e7-a128-b1d45ef7da0f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m</dd><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([-5802250., -5801250., -5800250., ..., -5521250., -5520250., -5519250.],\n",
+       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2010-01-31 ... 2010-12-31</div><input id='attrs-8748fde1-11a5-4da6-a0f5-800c5de67ded' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8748fde1-11a5-4da6-a0f5-800c5de67ded' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5a788cb1-116a-49b5-a9f5-a31a90ff66b1' class='xr-var-data-in' type='checkbox'><label for='data-5a788cb1-116a-49b5-a9f5-a31a90ff66b1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>long_name :</span></dt><dd>24-hour day based on local time</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;2010-01-31T00:00:00.000000000&#x27;, &#x27;2010-02-28T00:00:00.000000000&#x27;,\n",
        "       &#x27;2010-03-31T00:00:00.000000000&#x27;, &#x27;2010-04-30T00:00:00.000000000&#x27;,\n",
        "       &#x27;2010-05-31T00:00:00.000000000&#x27;, &#x27;2010-06-30T00:00:00.000000000&#x27;,\n",
        "       &#x27;2010-07-31T00:00:00.000000000&#x27;, &#x27;2010-08-31T00:00:00.000000000&#x27;,\n",
        "       &#x27;2010-09-30T00:00:00.000000000&#x27;, &#x27;2010-10-31T00:00:00.000000000&#x27;,\n",
        "       &#x27;2010-11-30T00:00:00.000000000&#x27;, &#x27;2010-12-31T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-7f0f06c9-4dec-42b3-8ce4-bea242251348' class='xr-section-summary-in' type='checkbox'  ><label for='section-7f0f06c9-4dec-42b3-8ce4-bea242251348' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-948ddd8e-f84a-4e2e-96e3-082f9d2a858f' class='xr-index-data-in' type='checkbox'/><label for='index-948ddd8e-f84a-4e2e-96e3-082f9d2a858f' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ -39000.0,  -40000.0,  -41000.0,  -42000.0,  -43000.0,  -44000.0,\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-4b864e69-f323-45ac-9f40-1fb5d1a0cf51' class='xr-section-summary-in' type='checkbox'  ><label for='section-4b864e69-f323-45ac-9f40-1fb5d1a0cf51' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-7fbe40b8-2ef9-437e-93ea-61a61fa75e82' class='xr-index-data-in' type='checkbox'/><label for='index-7fbe40b8-2ef9-437e-93ea-61a61fa75e82' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ -39000.0,  -40000.0,  -41000.0,  -42000.0,  -43000.0,  -44000.0,\n",
        "        -45000.0,  -46000.0,  -47000.0,  -48000.0,\n",
        "       ...\n",
        "       -613000.0, -614000.0, -615000.0, -616000.0, -617000.0, -618000.0,\n",
        "       -619000.0, -620000.0, -621000.0, -622000.0],\n",
-       "      dtype=&#x27;float32&#x27;, name=&#x27;y&#x27;, length=584))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-ae55558f-1eb0-4650-a26d-e4c715d88978' class='xr-index-data-in' type='checkbox'/><label for='index-ae55558f-1eb0-4650-a26d-e4c715d88978' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([-5802250.0, -5801250.0, -5800250.0, -5799250.0, -5798250.0, -5797250.0,\n",
+       "      dtype=&#x27;float32&#x27;, name=&#x27;y&#x27;, length=584))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-5b129991-f070-4812-9b2f-e863fb1678b0' class='xr-index-data-in' type='checkbox'/><label for='index-5b129991-f070-4812-9b2f-e863fb1678b0' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([-5802250.0, -5801250.0, -5800250.0, -5799250.0, -5798250.0, -5797250.0,\n",
        "       -5796250.0, -5795250.0, -5794250.0, -5793250.0,\n",
        "       ...\n",
        "       -5528250.0, -5527250.0, -5526250.0, -5525250.0, -5524250.0, -5523250.0,\n",
        "       -5522250.0, -5521250.0, -5520250.0, -5519250.0],\n",
-       "      dtype=&#x27;float32&#x27;, name=&#x27;x&#x27;, length=284))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-650a2e83-724d-4f54-b6f3-7edfff185b67' class='xr-index-data-in' type='checkbox'/><label for='index-650a2e83-724d-4f54-b6f3-7edfff185b67' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2010-01-31&#x27;, &#x27;2010-02-28&#x27;, &#x27;2010-03-31&#x27;, &#x27;2010-04-30&#x27;,\n",
+       "      dtype=&#x27;float32&#x27;, name=&#x27;x&#x27;, length=284))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-5b304d14-cd78-4b33-bd52-74ba477f5af4' class='xr-index-data-in' type='checkbox'/><label for='index-5b304d14-cd78-4b33-bd52-74ba477f5af4' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2010-01-31&#x27;, &#x27;2010-02-28&#x27;, &#x27;2010-03-31&#x27;, &#x27;2010-04-30&#x27;,\n",
        "               &#x27;2010-05-31&#x27;, &#x27;2010-06-30&#x27;, &#x27;2010-07-31&#x27;, &#x27;2010-08-31&#x27;,\n",
        "               &#x27;2010-09-30&#x27;, &#x27;2010-10-31&#x27;, &#x27;2010-11-30&#x27;, &#x27;2010-12-31&#x27;],\n",
-       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=&#x27;ME&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2c549070-d544-43ba-980c-7a1b9d7d6b6a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-2c549070-d544-43ba-980c-7a1b9d7d6b6a' class='xr-section-summary' >Attributes: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>daily maximum temperature</dd><dt><span>units :</span></dt><dd>degrees C</dd><dt><span>grid_mapping :</span></dt><dd>lambert_conformal_conic</dd><dt><span>cell_methods :</span></dt><dd>area: mean time: maximum</dd></dl></div></li></ul></div></div>"
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=&#x27;ME&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-f4576697-faaf-4937-9c47-3cbc984065ac' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f4576697-faaf-4937-9c47-3cbc984065ac' class='xr-section-summary' >Attributes: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>daily maximum temperature</dd><dt><span>units :</span></dt><dd>degrees C</dd><dt><span>grid_mapping :</span></dt><dd>lambert_conformal_conic</dd><dt><span>cell_methods :</span></dt><dd>area: mean time: maximum</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'tmax' (time: 12, y: 584, x: 284)>\n",
@@ -1513,30 +1381,30 @@
        "    cell_methods:  area: mean time: maximum"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Monthly resample\n",
-    "monthly_tmax_mean = ds['tmax'].resample(time=\"M\").mean()\n",
+    "monthly_tmax_mean = ds['tmax'].resample(time=\"ME\").mean()\n",
     "monthly_tmax_mean"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "b467bbe8",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7fda6213bcd0>"
+       "<matplotlib.collections.QuadMesh at 0x7f89f9aa95d0>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1559,7 +1427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b38876d",
+   "id": "9bbcdc53-a3e7-4cc0-8e03-7ca8131d2a39",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
This PR relates to https://github.com/NASA-Openscapes/corn/issues/16, which pins 4.9.3-development to the 2i2c Jupyterhub in the new "opendap" Python kernel. These commits add a couple of bullet points to the introduction markdown about how to switch to the new kernel, and also changes the resample code to use "ME" for suppressing a deprecation warning.