### PR TITLE
Fix cloud clinic redirect

### DIFF
--- a/tutorials/Earthdata-cloud-clinic.ipynb
+++ b/tutorials/Earthdata-cloud-clinic.ipynb
@@ -8,7 +8,7 @@
     "---\n",
     "title: \"NASA Earthdata Cloud Clinic\"\n",
     "aliases:\n",
-    "  - examples/Earthdata-cloud-clinic.html\n",
+    "  - /examples/Earthdata-cloud-clinic.html\n",
     "---"
    ]
   },
@@ -17,9 +17,6 @@
    "id": "bf218d52-4c89-48a1-bbb0-567e2378e0db",
    "metadata": {},
    "source": [
-    "# NASA Earthdata Cloud Clinic\n",
-    "\n",
-    "\n",
     "## Summary\n",
     "\n",
     "Welcome to the NASA Earthdata Cloud Clinic! \n",


### PR DESCRIPTION
Use `/` for site root dir in which to find `/examples/earthdata-cloud-clinic.html` for redirect. I also removed the duplicated title (it was in the yaml metadata and as a H1 header.

This closes #323