### PR TITLE
Document shared-password workshop access

### DIFF
--- a/policies-admin/add-folks-to-2i2c-github-teams.qmd
+++ b/policies-admin/add-folks-to-2i2c-github-teams.qmd
@@ -7,14 +7,21 @@ of access:
 
 1. [Individually-managed long-term access for NASA-Openscapes mentors and others](#individual-long-term-access)
 2. Access for participants in a NASA-Openscapes champions cohort
-3. Access for participants in a workshop
+3. Access for participants in a workshop using GitHub teams
+4. [Access for participants in a workshop using a shared password](leading-workshops.qmd#workshop-hub-access-via-shared-password)
 
-Access for for cohorts and workshop participants currently uses the [same 
-workflow](#adding-workshop-participants-or-champions-cohorts-as-a-batch).
+### Workshop access with a shared password
 
-We are also working on a method to give just-in-time access for specific workshops
-without using GitHub Teams or other managed access. Details of this process will be
-added as we finalize it.
+If you are hosting a workshop that has a large number of particpants, especially
+if they are not all comfortable with GitHub and particpants do not require
+access to the Hub when the workshop is complete, use the ["shared password" 
+access method](leading-workshops.qmd#workshop-hub-access-via-shared-password). This 
+access method allows instructors to share a single password with learners 
+at the start of the workshop, which they can use to log on the the Hub, and 
+eliminates the need to invite users to join the GitHub organization.
+
+Access for for cohorts and workshop participants using GitHub teams currently 
+uses the [same workflow](#adding-workshop-participants-or-champions-cohorts-as-a-batch).
 
 ## Individual long-term access
 
@@ -117,10 +124,12 @@ Participants in the Champions program workshops are given Openscapes
 2i2c JupyterHub access, as are participants in certain workshops run by NASA Openscapes Mentors.
 
 ::: {.callout-note}
-We have a newly developed process for giving people short-term access to the hub for workshops, with low
-overhead for instructors and particpants. This process
-removes the need to add people to a GitHub team, and gives participants "just in time" access to a special workshop hub with a 
-username and shared workshop-specific password. Policies and instructions for this currently being developed.
+We have a newly developed process for giving people short-term access to the hub 
+for workshops, with low overhead for instructors and particpants. This process 
+removes the need to add people to a GitHub team, and gives participants "just 
+in time" access to a special workshop hub with a username and shared 
+workshop-specific password. Instructions for this simplified setup are 
+[here](leading-workshops.qmd#workshop-hub-access-via-shared-password).
 :::
 
 We use a dedicated GitHub Organization - [nasa-openscapes-workshops](https://github.com/nasa-openscapes-workshops) - to manage access, with [GitHub Teams](https://github.com/orgs/nasa-openscapes-workshops/teams) for Champions Cohorts and certain workshops.

--- a/policies-admin/leading-workshops.qmd
+++ b/policies-admin/leading-workshops.qmd
@@ -53,7 +53,7 @@ with learners at the start of the workshop which they can use to log on the the
 Hub.
 
 ::: {.callout-tip collapse="true"}
-## Example email to 2i2c for a workshop with shared passwod authentication
+## Example email to 2i2c for a workshop with shared password authentication
 
 Hello,
 

--- a/policies-admin/leading-workshops.qmd
+++ b/policies-admin/leading-workshops.qmd
@@ -19,7 +19,7 @@ access patterns:
 
 ### Workshop Hub Access via GitHub Teams
 
-If you are hosting a smaller workshop with learners who are comfortable 
+If you are hosting a smaller workshop with learners  
 with GitHub and who require longer-term access to the Hub after the workshop, 
 follow the instructions to [add participants to the 2i2c Hub](add-folks-to-2i2c-github-teams.qmd) 
 via a GitHub Team. Then send an email to `support at 2i2c.freshdesk.com`.

--- a/policies-admin/leading-workshops.qmd
+++ b/policies-admin/leading-workshops.qmd
@@ -50,7 +50,7 @@ if they are not all comfortable with GitHub and particpants do not require
 access to the Hub when the workshop is complete, use the "shared password" 
 access. This access method allows the instructors to share a single password
 with learners at the start of the workshop which they can use to log on the the 
-Hub. 
+Hub.
 
 ::: {.callout-tip collapse="true"}
 ## Example email to 2i2c for a workshop with shared passwod authentication
@@ -74,3 +74,11 @@ Thank you!
 
 Erik
 :::
+
+Tell your learners that they will be able to access the Hub using the shared
+password for one week following the workshop, after which the password will
+be changed and the their home directories inside the Hub will be removed.
+
+One week after the workshop, send another email to `support at 2i2c.freshdesk.com`
+and request that the password be reset and users' home directories from the
+workshop be removed.

--- a/policies-admin/leading-workshops.qmd
+++ b/policies-admin/leading-workshops.qmd
@@ -8,14 +8,24 @@ This section, under development, will include information for workshop prep, set
 
 ## Using the Openscapes 2i2c Hub in a workshop
 
-<!-- TODO: Add policies/instructions for setting up workshop with "just-in-time" access -->
+- Check with Luis that the Hub image has the packages you need
+- Reach out to 2i2c _a month in advance_ via email `support at 2i2c.freshdesk.com` 
+  (examples below) to tell them about the workshop date, start and end times, 
+  \# of participants, anticipated level of resources to be used, access 
+  method, and if appropriate, a desired password.
 
--   Check with Luis that the Hub image has the packages you need
--   Reach out to 2i2c a month in advance via email `support at 2i2c.freshdesk.com` (example below) to tell them about the workshop date, start and end times, \# of participants, anticipated level of resources to be used.
--   [Add participants to the 2i2c Hub](add-folks-to-2i2c-github-teams.qmd) via a GitHub Team
+We divide types of workshops into two different categories, with different
+access patterns:
+
+### Workshop Hub Access via GitHub Teams
+
+If you are hosting a smaller workshop with learners who are comfortable 
+with GitHub and who require longer-term access to the Hub after the workshop, 
+follow the instructions to [add participants to the 2i2c Hub](add-folks-to-2i2c-github-teams.qmd) 
+via a GitHub Team. Then send an email to `support at 2i2c.freshdesk.com`.
 
 ::: {.callout-tip collapse="true"}
-## Example email to 2i2c for a workshop
+## Example email to 2i2c for a workshop with GitHub authentication
 
 Hello,
 
@@ -25,10 +35,42 @@ Title: Data Access Workshop for NASA’s SWOT Satellite\
 Date: February 13, 2024\
 Duration/Time: half day, 9:00 am-12:30 pm HST (Honolulu, HI).\
 Expected Usage: 3.7 GB per person (\~50 people)
+The URL of the hub that will be used for the event: https://openscapes.2i2c.cloud/
+Access Method: GitHub Team
 
 Thank you!
 
 Cassie
 :::
 
-### [How to Add Folks to the 2i2c Hub](add-folks-to-2i2c-github-teams.qmd)
+### Workshop Hub Access via Shared Password
+
+If you are hosting a workshop that has a large number of particpants, especially
+if they are not all comfortable with GitHub and particpants do not require
+access to the Hub when the workshop is complete, use the "shared password" 
+access. This access method allows the instructors to share a single password
+with learners at the start of the workshop which they can use to log on the the 
+Hub. 
+
+::: {.callout-tip collapse="true"}
+## Example email to 2i2c for a workshop with shared passwod authentication
+
+Hello,
+
+The LP DAAC and Openscapes have an upcoming event where we are planning to use 
+the Openscapes Hub. Here’s the main information:
+
+The GitHub handle or name of the community representative: [github username], email@somedomain.com
+The date when the event will start: July 7, 2024
+The date when the event will end: July ​7, 2024
+What hours of the day will participants be active? 1:00pm - 5pm EEST (Athens, Greece).
+Number of attendees: ~40
+Resources per user: 14.8GB RAM / up to 3.7 CPU
+The URL of the hub that will be used for the event: https://workshop.openscapes.2i2c.cloud/
+Access method: shared password
+Password choice: [YouChooseAPassword]
+
+Thank you!
+
+Erik
+:::


### PR DESCRIPTION
Hi @jules32, Here is a first attempt at documenting the use of the shared password workshop access. I added most of the content to leading-workshops.qmd to mirror the workshop setup alread there, and updated the "How to add folks..." to highlight the new process and link back to leading-workshops.qmd.

Happy for any tweaks or feedback!