### PR TITLE
Add 3 Champions Cohorts to Workshop page

### DIFF
--- a/workshops/index.qmd
+++ b/workshops/index.qmd
@@ -45,7 +45,7 @@ The goal of this workshop, as part of the [2023 Space and Sustainability Colloqu
 
 ## 2023 Champions Cohort
 
-**<https://nasa-openscapes.github.io/news/2023-08-01-nasa-champions/>**
+**<https://nasa-openscapes.github.io/news/2023-08-01-nasa-champions>**
 
 The 2023 NASA Openscapes Champions Cohort had exciting progress for research teams using NASA Earthdata in the Cloud. From April-June 2023, the NASA Openscapes project team co-led the second Champions Cohort with NASA Mentors who spanned 7 Distributed Active Archive Centers (DAACs). The Cohort included 7 research teams from academia and government that were curious about working with NASA Earthdata in the Cloud. Cloud migration takes time, so in the ten weeks we worked together, the focus was on planning the transition, identifying resources, and initial experiments using the Cloud through our 2i2c JupyterHub. All of this work is underpinned by Openscapes and NASA’s commitment to Open science practices. The news page above links to Mentor lessons and what the teams achieved!
 
@@ -60,6 +60,13 @@ The goal of the workshop is expose ECOSTRESS data users to ECOSTRESS version 2 (
 [**https://podaac.github.io/2022-SWOT-Ocean-Cloud-Workshop/**](https://podaac.github.io/2022-SWOT-Ocean-Cloud-Workshop/){.uri}
 
 The goal of the workshop is to get ready for Surface Water and Ocean Topography ([SWOT](https://swot.jpl.nasa.gov/)) and enable the (oceanography) science team to be ready for processing and handling the large volumes of SWOT SSH data in the cloud. Learning objectives focus on how to access the [simulated SWOT L2 SSH data](https://podaac.jpl.nasa.gov/announcements/2022-01-31-Release-simulated-SWOT-SSH-version1-datasets) from Earthdata Cloud either by downloading or accessing the data on the cloud. PO.DAAC is the NASA archive for the SWOT mission, and once launched will be making data available via the NASA Earthdata Cloud, hosted in AWS.
+
+## 2022 Champions Cohort
+
+**<https://nasa-openscapes.github.io/news/2022-05-12-nasa-2022-champions>**
+
+The 2022 Champions Cohort focused on shifting from downloading data to Cloud access. In Spring 2022 we led our first NASA Openscapes Champions Cohort for 10 research teams that work with NASA EarthData. This cohort is funded by NASA and part of our NASA Openscapes Framework project. For this Cohort, we co-led the cohort with the NASA DAAC mentors and we focused on shifting toward Open science, collaborative, reproducible practices to support research teams as they transition from the download model to the Cloud. We also actively experimented with cloud data access through the Openscapes 2i2c-hosted JupyterHub. The news page above links to Mentor lessons and what the teams achieved!
+
 
 ## 2021 Cloud AGU Workshop
 

--- a/workshops/index.qmd
+++ b/workshops/index.qmd
@@ -16,6 +16,13 @@ The NASA Plankton, Aerosol, Cloud, ocean Ecosystem (PACE) Hackweek was a social-
 
 The Surface Water and Ocean Topography (SWOT) satellite, a joint NASA-CNES venture, provides unprecedented measurements of surface water extents and elevations for hydrologic science and applications. This workshop focuses on the SWOT Hydrology datasets including river and lake vector data in shapefiles, and raster, pixel cloud, and pixel vector data in netCDF. In this pre-meeting workshop hosted by the Physical Oceanography Distributed Active Archive Center (PO.DAAC) for the AGU Chapman: Remote Sensing of the Water Cycle Conference, participants are introduced to SWOT and the various ways to access and utilize its data products, including via cloud computing, local download, and data transformation tools.
 
+## 2024 Champions Cohort
+
+**<https://nasa-openscapes.github.io/news/2024-07-24-2024-nasa-champions-cohort>**
+
+From April-May 2024, the NASA Mentors who span 11 Distributed Active Archive Centers (DAACs) co-led the third Champions Cohort with the NASA Openscapes project team, this year focusing on, teaching lessons they adapted for geospatial and cloud analysis. The Cohort included 9 international research teams from academia and government that were curious about working with NASA Earthdata in the Cloud. Many teams were interested in using data from multiple DAACs. User cloud adaption takes time, given the new conceptual mindsets and technical skillsets it requires. During the ten weeks we worked together, NASA Mentors refined and extended previous lessons to focus on thinking through and planning the transition to using the Cloud for science research and applications, and initial experiments using the Cloud through our 2i2c JupyterHub. The news page above links to Mentor lessons, YouTube clips, and what the teams achieved!
+
+
 ## 2023 Cloud Workshop at AGU
 
 [**https://nasa-openscapes.github.io/2023-Cloud-Workshop-AGU**](https://nasa-openscapes.github.io/2023-Cloud-Workshop-AGU)

--- a/workshops/index.qmd
+++ b/workshops/index.qmd
@@ -6,7 +6,7 @@ We develop tutorials for teaching events that each have their own e-book. The fo
 
 ## 2024 PACE Hackweek
 
-[**https://pacehackweek.github.io/pace-2024/**](https://pacehackweek.github.io/pace-2024/)
+[**https://pacehackweek.github.io/pace-2024**](https://pacehackweek.github.io/pace-2024/)
 
 The NASA Plankton, Aerosol, Cloud, ocean Ecosystem (PACE) Hackweek was a social-coding sprint held August 4-8 in-person at the [University of Maryland Baltimore County](https://umbc.edu/), and fiscally supported by the [Ocean Carbon & Biogeochemistry](https://www.us-ocb.org/) program. The course utilized the [CryoCloud JupyterHub](https://book.cryointhecloud.com/intro.html), which is maintained through a structured partnership between organizers from the NASA Cryosphere community and the International Interactive Computing Collaboration (2i2c) team. Forty one participants from 89 applicants attended the event, including 10 who traveled from abroad. Each day was divided into science lectures, coding tutorials, and group project work. Every evening included a social event: a Bob Ross Paint Night, a “fireside chat” with NASA Program Managers, a local crab feast at Patapsco State Park, Nerd Nite ("talent" show), and PACE Trivia. We hacked on many interesting science questions, such as detecting anomalies in PACE hyperspectral remote sensing reflectance signals, studying relationships between aerosol and surface ocean properties impacted by wildfires and smoke plumes, and studying biological and physical characteristics of a Gulf Stream eddy using both PACE and SWOT data. Links to slides, notebooks, project repositories, and recordings (when available from the video editor) are available on the website.
 
@@ -20,8 +20,7 @@ The Surface Water and Ocean Topography (SWOT) satellite, a joint NASA-CNES ventu
 
 **<https://nasa-openscapes.github.io/news/2024-07-24-2024-nasa-champions-cohort>**
 
-From April-May 2024, the NASA Mentors who span 11 Distributed Active Archive Centers (DAACs) co-led the third Champions Cohort with the NASA Openscapes project team, this year focusing on, teaching lessons they adapted for geospatial and cloud analysis. The Cohort included 9 international research teams from academia and government that were curious about working with NASA Earthdata in the Cloud. Many teams were interested in using data from multiple DAACs. User cloud adaption takes time, given the new conceptual mindsets and technical skillsets it requires. During the ten weeks we worked together, NASA Mentors refined and extended previous lessons to focus on thinking through and planning the transition to using the Cloud for science research and applications, and initial experiments using the Cloud through our 2i2c JupyterHub. The news page above links to Mentor lessons, YouTube clips, and what the teams achieved!
-
+The 2024 NASA Champions cohort focused on data strategies for when to use cloud, coding strategies for parallelization, & first examples of big science in the Cloud. From April-May 2024, the NASA Mentors who span 11 Distributed Active Archive Centers (DAACs) co-led the third Champions Cohort with the NASA Openscapes project team, this year focusing on, teaching lessons they adapted for geospatial and cloud analysis. The Cohort included 9 international research teams from academia and government that were curious about working with NASA Earthdata in the Cloud. Many teams were interested in using data from multiple DAACs. User cloud adaption takes time, given the new conceptual mindsets and technical skillsets it requires. During the ten weeks we worked together, NASA Mentors refined and extended previous lessons to focus on thinking through and planning the transition to using the Cloud for science research and applications, and initial experiments using the Cloud through our 2i2c JupyterHub. The news page above links to Mentor lessons, YouTube clips, and what the teams achieved!
 
 ## 2023 Cloud Workshop at AGU
 
@@ -43,6 +42,12 @@ This workshop is hosted by [NASA Land Processes Distributed Activate Archive Cen
 [**https://nasa-openscapes.github.io/2023-ssc/**](https://nasa-openscapes.github.io/2023-ssc/){.uri}
 
 The goal of this workshop, as part of the [2023 Space and Sustainability Colloquium](https://espacioysostenibilidad.com/en/#), is to demonstrate how to find, access, and work with GEDI and ICESat-2 data from the Earthdata Cloud. Participants will learn how to search for and download data from NASA’s Earthdata Search Client, a graphical user interface (GUI) for search, discovery, and download application for also EOSDIS data assets. Participants will learn how to perform in-cloud data search, access, and processing routines where no data download is required, and data analysis can take place next to the data in the cloud.
+
+## 2023 Champions Cohort
+
+**<https://nasa-openscapes.github.io/news/2023-08-01-nasa-champions/>**
+
+The 2023 NASA Openscapes Champions Cohort had exciting progress for research teams using NASA Earthdata in the Cloud. From April-June 2023, the NASA Openscapes project team co-led the second Champions Cohort with NASA Mentors who spanned 7 Distributed Active Archive Centers (DAACs). The Cohort included 7 research teams from academia and government that were curious about working with NASA Earthdata in the Cloud. Cloud migration takes time, so in the ten weeks we worked together, the focus was on planning the transition, identifying resources, and initial experiments using the Cloud through our 2i2c JupyterHub. All of this work is underpinned by Openscapes and NASA’s commitment to Open science practices. The news page above links to Mentor lessons and what the teams achieved!
 
 ## 2022 ECOSTRESS Cloud Workshop
 


### PR DESCRIPTION
This is a first step to having Champions program visible and linkable from the Cookbook. #344 . In the future we can also cross-link slide decks and recordings here as well.