### PR TITLE
link to new harmony tutorial; fix tutorials index page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ examples/NSIDC/data
 external/
 how-tos/test.nc
 earthdata-cloud-cookbook.code-workspace
+
+**/*.quarto_ipynb

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -108,7 +108,7 @@ website:
           - text: "Agriculture Observations"
             href: tutorials/Observing_Seasonal_Ag_Changes.ipynb
           - text: "Subsetting Data with Harmony"
-            href: tutorials/IS2_Harmony.ipynb
+            href: tutorials/Harmony.ipynb
           - text: "OPeNDAP Access" 
             href: tutorials/Earthdata_Cloud__Data_Access_OPeNDAP_Example.ipynb
           - text: "Pygeoweaver Workflow Demo"

--- a/tutorials/index.qmd
+++ b/tutorials/index.qmd
@@ -1,16 +1,5 @@
 ---
 title: Tutorials
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .qmd
-      format_name: quarto
-      format_version: '1.0'
-      jupytext_version: 1.16.1
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
 ---
 
 The following tutorials are meant to present example workflows with NASA Earthdata in the cloud from a variety of use cases. The tutorials exemplify the advantages of working with NASA Earthdata in the cloud and aim to provide a starting point for exploring what your workflows could look like in the cloud. 
@@ -32,8 +21,7 @@ The following tutorials are meant to present example workflows with NASA Earthda
 ### **Observing Seasonality in Agricultural Areas** - [Tutorial](Observing_Seasonal_Ag_Changes.ipynb)
 *Working with HLS Landsat and Sentinel-2 data products in the cloud*
 
-### **Subsetting ICESat-2 Data Using NASA Harmony** - [Tutorial]
-(IS2_Harmony.ipynb)
+### **Subsetting NASA Earthdata Using Harmony** - [Tutorial](Harmony.ipynb)
 *Requesting spatial and temporal subsets of ICESat-2 L2A and L3A data*
 
 ### **Using OPeNDAP in the Cloud** - [Tutorial](Earthdata_Cloud__Data_Access_OPeNDAP_Example.ipynb)


### PR DESCRIPTION
I forgot to make sure the new Harmony tutorial was linked from `tutorials/index.html`, as well as from the sidebar after #399 - this fixes that.

I also removed the jupyter/python info from `tutorials/index.qmd` yaml header, as it's only text in the file, and it wasn't rendering the new content for some reason with it in there.