### PR TITLE
Update Harmony.ipynb

### DIFF
--- a/tutorials/Harmony.ipynb
+++ b/tutorials/Harmony.ipynb
@@ -82,8 +82,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Harmony services (added Environment for testing in UAT; can remove for pull request)\n",
-    "from harmony import BBox, Client, Collection, Request, LinkType, CapabilitiesRequest, Environment \n",
+    "# Harmony services \n",
+    "from harmony import BBox, Client, Collection, Request, LinkType, CapabilitiesRequest \n",
     "\n",
     "# Earthdata Login Authentication\n",
     "import earthaccess \n",


### PR DESCRIPTION
removed the Environment method from the harmony import, since it was for testing in UAT before the data were available in Production.