### PR TITLE
push new link

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -40,7 +40,7 @@ website:
         href: our-cookbooks.qmd
         contents:
           - text: "Ocean, climate, and surface water data tutorials from PO.DAAC"
-            href: tutorials/Earthdata-cloud-clinic.ipynb 
+            href: https://podaac.github.io/tutorials/
           - text: "Mission-specific tutorials for ASDC"
             href: https://nasa.github.io/ASDC_Data_and_User_Services/        
       - text: "Glossary & Cheatsheets" 


### PR DESCRIPTION
At Coworking, we're directing the PO.DAAC link in the Cookbook nav bar to the PO.DAAC Cookbook, as intended. 