### PR TITLE
Add issue template for removing content

### DIFF
--- a/.github/ISSUE_TEMPLATE/remove-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/remove-notebook.yml
@@ -42,9 +42,18 @@ body:
     attributes:
       label: Migration plan
       description: >
-        Do we need to do anything for redirects, update links in other notebooks, 
+        Do we need to do anything for redirects, update links in other notebooks,
         or otherwise help users transition away from this notebook? If so, and
-        it is decided that the notebook should be removed, please include those 
+        it is decided that the notebook should be removed, please include those
         changes in the PR to remove the notebook.
     validations:
       required: false
+
+  - type: checkboxes
+    attributes:
+      label: Final decision
+      description: >
+        After discussion, record the outcome here before opening a PR or closing the issue.
+      options:
+        - label: Remove this notebook (open a PR to remove it)
+        - label: Keep this notebook (close issue, open an issue to update it instead using the "Update notebook" issue template)


### PR DESCRIPTION
This adds an issue template to propose removing a notebook from the cookbook. It has sections to describe the notebook, why it should be removed, what (if anything) replaces/supersedes it, and what needs to be done (if anything) for redirects or link updating.

Closes #422 