### PR TITLE
ordering of issue templates and other small improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,6 +1,6 @@
 name: 🪳 Bug
 description: >
-  A bug is an issue that differs from documentation or has unexpected behavior.
+  Report something unexpected or otherwise different from documented behavior
 title: "[BUG] {{ title }}"
 labels:
   - bug

--- a/.github/ISSUE_TEMPLATE/2-update-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/2-update-notebook.yml
@@ -48,14 +48,8 @@ body:
       value: |
         ### Final resolution
 
-        After discussion, how this feedback is addressed will show up in how
-        this issue is resolved.
+        After discussion, how this feedback is addressed will show up in how this issue is resolved.
 
-        1. Closed as completed: merging a PR to update this notebook automatically
-          closed this issue.
-        2. Closed as duplicate: the author or a maintainer closed this issue
-          after linking an existing issue with the "🪏 Update notebook" template
-          or a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=4-remove-notebook.yml)
-          with the "🥀 Remove notebook" template.
-        3. Closed as won't fix: the author or a maintainer closed this issue
-          manually if no changes are necessary.
+        1. Closed as completed: merging a PR to update this notebook automatically closed this issue.
+        2. Closed as duplicate: the author or a maintainer closed this issue after linking an existing issue with the "🪏 Update notebook" template or a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=4-remove-notebook.yml) with the "🥀 Remove notebook" template.
+        3. Closed as won't fix: the author or a maintainer closed this issue manually if no changes are necessary.

--- a/.github/ISSUE_TEMPLATE/2-update-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/2-update-notebook.yml
@@ -45,11 +45,17 @@ body:
 
   - type: markdown
     attributes:
-      value: |
+      value: >
         ### Final resolution
 
-        After discussion, how this feedback is addressed will show up in how this issue is resolved.
+        After discussion, how this feedback is addressed will show up in how
+        this issue is resolved.
 
-        1. Closed as completed: merging a PR to update this notebook automatically closed this issue.
-        2. Closed as duplicate: the author or a maintainer closed this issue after linking an existing issue with the "🪏 Update notebook" template or a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=4-remove-notebook.yml) with the "🥀 Remove notebook" template.
-        3. Closed as won't fix: the author or a maintainer closed this issue manually if no changes are necessary.
+        1. Closed as completed: merging a PR to update this notebook
+           automatically closed this issue.
+        2. Closed as duplicate: the author or a maintainer closed this issue
+           after linking an existing issue with the "🪏 Update notebook" template
+           or a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=4-remove-notebook.yml)
+           with the "🥀 Remove notebook" template.
+        3. Closed as won't fix: the author or a maintainer closed this issue
+           manually if no changes are necessary.

--- a/.github/ISSUE_TEMPLATE/2-update-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/2-update-notebook.yml
@@ -46,7 +46,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Final resolution
+        ### Final resolution
 
         After discussion, how this feedback is addressed will show up in how
         this issue is resolved.

--- a/.github/ISSUE_TEMPLATE/2-update-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/2-update-notebook.yml
@@ -1,5 +1,5 @@
 name: 🪏 Update notebook
-description: Propose updating a notebook in the Cookbook
+description: Improve an existing notebook in the Cookbook
 title: "[UPDATE] "
 labels:
   - "content: update"
@@ -27,7 +27,7 @@ body:
 
   - type: textarea
     attributes:
-      label: Recommended updates
+      label: Recommended changes
       description: >
         What changes would bring this notebook up to date? Include suggested
         code snippets, links to relevant documentation, or other resources.
@@ -55,7 +55,7 @@ body:
           closed this issue.
         2. Closed as duplicate: the author or a maintainer closed this issue
           after linking an existing issue with the "🪏 Update notebook" template
-          or a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=remove-notebook.yml)
+          or a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=4-remove-notebook.yml)
           with the "🥀 Remove notebook" template.
         3. Closed as won't fix: the author or a maintainer closed this issue
           manually if no changes are necessary.

--- a/.github/ISSUE_TEMPLATE/3-add-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/3-add-notebook.yml
@@ -2,7 +2,7 @@ name: 🌱 Add notebook
 description: Suggest a new notebook for the Cookbook
 title: "[Add] "
 labels:
-  - "content: add"
+  - "content: new"
   - maintenance
 assignees:
   -

--- a/.github/ISSUE_TEMPLATE/3-add-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/3-add-notebook.yml
@@ -42,7 +42,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Contributing
+        ### Contributing
 
         We would be thrilled if you are also interested in starting to write the proposed
         notebook! We can provide the best support if you share updates on GitHub as you go.
@@ -56,7 +56,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Final resolution
+        ### Final resolution
 
         After discussion, how this feedback is addressed will show up in how the
         issue is resolved.

--- a/.github/ISSUE_TEMPLATE/3-add-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/3-add-notebook.yml
@@ -1,5 +1,5 @@
 name: 🌱 Add notebook
-description: Propose a new notebook for the Cookbook
+description: Suggest a new notebook for the Cookbook
 title: "[Add] "
 labels:
   - "content: add"
@@ -45,8 +45,8 @@ body:
         ## Contributing
 
         We would be thrilled if you are also interested in starting to write the proposed
-        notebook! We can provide the best support if you share updates to GitHub as you write 
-        it. If there is someone who you think would be a better fit for this issue or from whom you'd like feedback,
+        notebook! We can provide the best support if you share updates on GitHub as you go.
+        If there is someone who you think would be a better fit for this issue or from whom you'd like feedback,
         please reply below and `@mention` their GitHub username.
 
         Our [contributing workflow](https://nasa-openscapes.github.io/earthdata-cloud-cookbook/contributing/workflow.html)
@@ -64,7 +64,7 @@ body:
         1. Closed as completed: Merging a PR to add the proposed notebook automatically
           closed this issue.
         2. Closed as duplicate: The author or maintainer closed this issue after
-          linking a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=update-notebook.yml)
+          linking a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=2-update-notebook.yml)
           created from the "🪏 Update notebook" template.
         3. Closed as won't fix: The author or maintainer closed this issue
           if no changes are necessary.

--- a/.github/ISSUE_TEMPLATE/3-add-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/3-add-notebook.yml
@@ -44,27 +44,17 @@ body:
       value: |
         ### Contributing
 
-        We would be thrilled if you are also interested in starting to write the proposed
-        notebook! We can provide the best support if you share updates on GitHub as you go.
-        If there is someone who you think would be a better fit for this issue or from whom you'd like feedback,
-        please reply below and `@mention` their GitHub username.
+        We would be thrilled if you are also interested in starting to write the proposed notebook! We can provide the best support if you share updates on GitHub as you go. If there is someone who you think would be a better fit for this issue or from whom you'd like feedback, please reply below and `@mention` their GitHub username.
 
-        Our [contributing workflow](https://nasa-openscapes.github.io/earthdata-cloud-cookbook/contributing/workflow.html)
-        describes how to work with GitHub branches and Quarto. We hold bi-weekly co-working sessions
-        you are welcome to join, or ask on Slack for support anytime!
+        Our [contributing workflow](https://nasa-openscapes.github.io/earthdata-cloud-cookbook/contributing/workflow.html) describes how to work with GitHub branches and Quarto. We hold bi-weekly co-working sessions you are welcome to join, or ask on Slack for support anytime!
 
   - type: markdown
     attributes:
       value: |
         ### Final resolution
 
-        After discussion, how this feedback is addressed will show up in how the
-        issue is resolved.
+        After discussion, how this feedback is addressed will show up in how the issue is resolved.
 
-        1. Closed as completed: Merging a PR to add the proposed notebook automatically
-          closed this issue.
-        2. Closed as duplicate: The author or maintainer closed this issue after
-          linking a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=2-update-notebook.yml)
-          created from the "🪏 Update notebook" template.
-        3. Closed as won't fix: The author or maintainer closed this issue
-          if no changes are necessary.
+        1. Closed as completed: Merging a PR to add the proposed notebook automatically closed this issue.
+        2. Closed as duplicate: The author or maintainer closed this issue after linking a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=2-update-notebook.yml) created from the "🪏 Update notebook" template.
+        3. Closed as won't fix: The author or maintainer closed this issue if no changes are necessary.

--- a/.github/ISSUE_TEMPLATE/4-remove-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/4-remove-notebook.yml
@@ -53,7 +53,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Final resolution
+        ### Final resolution
 
         After discussion, how this feedback is addressed will show up in how the
         issue is resolved.

--- a/.github/ISSUE_TEMPLATE/4-remove-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/4-remove-notebook.yml
@@ -55,13 +55,8 @@ body:
       value: |
         ### Final resolution
 
-        After discussion, how this feedback is addressed will show up in how the
-        issue is resolved.
+        After discussion, how this feedback is addressed will show up in how the issue is resolved.
 
-        1. Closed as completed: Merging a PR to remove this notebook automatically
-          closed this issue.
-        2. Closed as duplicate: The author or maintainer closed this issue after
-          linking a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=2-update-notebook.yml)
-          created from the "🪏 Update notebook" template.
-        3. Closed as won't fix: The author or maintainer closed this issue
-          if no changes are necessary.
+        1. Closed as completed: Merging a PR to remove this notebook automatically closed this issue.
+        2. Closed as duplicate: The author or maintainer closed this issue after linking a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=2-update-notebook.yml) created from the "🪏 Update notebook" template.
+        3. Closed as won't fix: The author or maintainer closed this issue if no changes are necessary.

--- a/.github/ISSUE_TEMPLATE/4-remove-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/4-remove-notebook.yml
@@ -61,7 +61,7 @@ body:
         1. Closed as completed: Merging a PR to remove this notebook automatically
           closed this issue.
         2. Closed as duplicate: The author or maintainer closed this issue after
-          linking a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=update-notebook.yml)
+          linking a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=2-update-notebook.yml)
           created from the "🪏 Update notebook" template.
         3. Closed as won't fix: The author or maintainer closed this issue
           if no changes are necessary.


### PR DESCRIPTION
Fixes #430 

- [x] ordered
- [x] labels corrected and/or created
- [x] line breaks in markdown resolved

Really a workaround rather than a resolution on the line breaks. Not ideal for editors, but I suspect there's a problem on GitHub's side with parsing multi-line strings as raw markdown.