### PR TITLE
Update yaml formatting in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -57,11 +57,16 @@ body:
   - type: textarea
     attributes:
       label: Additional Context
-      description: |
-        Any additional information that might be helpful in resolving this issue, such as:
+      description: >
+        Any additional information that might be helpful in resolving this 
+        issue, such as:
+
         - Error messages or stack traces
+        
         - Relevant configuration files or code snippets
 
-        Tip: You can attach files or images by clicking this area to highlight it and then dragging files in.
+
+        Tip: You can attach files or images by clicking this area to highlight 
+        it and then dragging files in.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/2-update-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/2-update-notebook.yml
@@ -11,8 +11,10 @@ body:
     attributes:
       label: Notebook to update
       description: >
-        What specific page or notebook needs to be updated? Provide a full URL or path.
-      placeholder: "https://nasa-openscapes.github.io/earthdata-cloud-cookbook/how-tos/read_data.html"
+        What specific page or notebook needs to be updated? Provide a full URL
+        or path.
+      placeholder: |
+        https://nasa-openscapes.github.io/earthdata-cloud-cookbook/how-tos/read_data.html
     validations:
       required: true
 
@@ -45,7 +47,7 @@ body:
 
   - type: markdown
     attributes:
-      value: |
+      value: >
         ### Final resolution
 
         After discussion, how this feedback is addressed will show up in how
@@ -53,9 +55,11 @@ body:
 
         1. Closed as completed: merging a PR to update this notebook
         automatically closed this issue.
+
         2. Closed as duplicate: the author or a maintainer closed this issue
         after linking an existing issue with the "🪏 Update notebook" template
         or a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=4-remove-notebook.yml)
         with the "🥀 Remove notebook" template.
+
         3. Closed as won't fix: the author or a maintainer closed this issue
         manually if no changes are necessary.

--- a/.github/ISSUE_TEMPLATE/3-add-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/3-add-notebook.yml
@@ -12,8 +12,8 @@ body:
     attributes:
       label: Rationale
       description: >
-        Why should a new notebook be created? What hurdle that Earthdata users encounter with
-        cloud computing will the content help them clear?
+        Why should a new notebook be created? What hurdle that Earthdata users 
+        encounter with cloud computing will the content help them clear?
     validations:
       required: true
 
@@ -41,20 +41,34 @@ body:
 
   - type: markdown
     attributes:
-      value: |
+      value: >
         ### Contributing
 
-        We would be thrilled if you are also interested in starting to write the proposed notebook! We can provide the best support if you share updates on GitHub as you go. If there is someone who you think would be a better fit for this issue or from whom you'd like feedback, please reply below and `@mention` their GitHub username.
+        We would be thrilled if you are also interested in starting to write the
+        proposed notebook! We can provide the best support if you share updates
+        on GitHub as you go. If there is someone who you think would be a better
+        fit for this issue or from whom you'd like feedback, please reply below
+        and `@mention` their GitHub username.
 
-        Our [contributing workflow](https://nasa-openscapes.github.io/earthdata-cloud-cookbook/contributing/workflow.html) describes how to work with GitHub branches and Quarto. We hold bi-weekly co-working sessions you are welcome to join, or ask on Slack for support anytime!
+        Our [contributing workflow](https://nasa-openscapes.github.io/earthdata-cloud-cookbook/contributing/workflow.html)
+        describes how to work with GitHub branches and Quarto. We hold bi-weekly
+        co-working sessions you are welcome to join, or ask on Slack for support
+        anytime!
 
   - type: markdown
     attributes:
-      value: |
+      value: >
         ### Final resolution
 
-        After discussion, how this feedback is addressed will show up in how the issue is resolved.
+        After discussion, how this feedback is addressed will show up in how the
+        issue is resolved.
 
-        1. Closed as completed: Merging a PR to add the proposed notebook automatically closed this issue.
-        2. Closed as duplicate: The author or maintainer closed this issue after linking a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=2-update-notebook.yml) created from the "🪏 Update notebook" template.
-        3. Closed as won't fix: The author or maintainer closed this issue if no changes are necessary.
+        1. Closed as completed: Merging a PR to add the proposed notebook 
+        automatically closed this issue.
+
+        2. Closed as duplicate: The author or maintainer closed this issue after
+        linking a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=2-update-notebook.yml) 
+        created from the "🪏 Update notebook" template.
+
+        3. Closed as won't fix: The author or maintainer closed this issue if no
+        changes are necessary.

--- a/.github/ISSUE_TEMPLATE/4-remove-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/4-remove-notebook.yml
@@ -12,7 +12,8 @@ body:
       label: Content to remove
       description: >
         What specific page or notebook should be removed? Provide a full URL or path.
-      placeholder: "https://nasa-openscapes.github.io/earthdata-cloud-cookbook/how-tos/read_data.html"
+      placeholder: |
+        https://nasa-openscapes.github.io/earthdata-cloud-cookbook/how-tos/read_data.html
     validations:
       required: true
 
@@ -34,8 +35,9 @@ body:
         be used instead. Include the path(s) and a brief note on how each one
         covers the same ground. If you want to link to or import an external 
         notebook, please open an issue or PR to add it.
-      placeholder: |
-        - how-tos/find-data/find-data-earthaccess-v2.qmd: covers the same search workflow with the current API
+      placeholder: >
+        - how-tos/find-data/find-data-earthaccess-v2.qmd: covers the same search
+        workflow with the current API
     validations:
       required: false
 
@@ -52,11 +54,18 @@ body:
 
   - type: markdown
     attributes:
-      value: |
+      value: >
         ### Final resolution
 
-        After discussion, how this feedback is addressed will show up in how the issue is resolved.
+        After discussion, how this feedback is addressed will show up in how the
+        issue is resolved.
 
-        1. Closed as completed: Merging a PR to remove this notebook automatically closed this issue.
-        2. Closed as duplicate: The author or maintainer closed this issue after linking a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=2-update-notebook.yml) created from the "🪏 Update notebook" template.
-        3. Closed as won't fix: The author or maintainer closed this issue if no changes are necessary.
+        1. Closed as completed: Merging a PR to remove this notebook
+        automatically closed this issue.
+
+        2. Closed as duplicate: The author or maintainer closed this issue after
+        linking a [new issue](https://github.com/NASA-Openscapes/earthdata-cloud-cookbook/issues/new?template=2-update-notebook.yml)
+        created from the "🪏 Update notebook" template.
+
+        3. Closed as won't fix: The author or maintainer closed this issue if no
+        changes are necessary.


### PR DESCRIPTION
* use `>` to enable line wrapping, `|` to preserve line breaks
* add blank lines to force line breaks and lists in sections with `>`
* And apparently two blank lines after an unordered list if you want a new paragraph (see bug.yml)

@itcarroll I've taken one more stab at it so they all use the same formatting, and hopefully render nicely, if you want to have a look. Tested in another repo here: https://github.com/ateucher/test-issue-templates/issues.

Closes #430 