### PR TITLE
Comment when manual deploy preview trigger is necessary

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,13 +11,19 @@ name: Deploy Preview
 jobs:
 
   is-external-pr:
-    # Be helpful with reviewer and remind them to trigger a deploy preview if the PR is from a fork.
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
+    # Post a one-time comment on fork PRs reminding maintainers to trigger the deploy preview manually.
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true && github.event.action == 'opened' }}
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - name: Error with message for manual deploy
+      - name: Comment with instructions for manual deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::error title=Manual action required for preview::PR from fork can't be deployed as preview to Netlify automatically. Use '/deploy-preview' command in comments to trigger the preview manually."
+          gh api repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/comments \
+            --method POST \
+            --field body='This PR is from a fork and cannot be automatically deployed as a preview. A maintainer can trigger the preview by commenting `/deploy-preview`.'
         shell: bash
 
   role-of-commenter:
@@ -35,22 +41,22 @@ jobs:
         shell: bash
 
   build-deploy-preview:
-    # Deploy a preview only if 
+    # Deploy a preview only if
     # - the PR is not from a fork,
     # - requested by PR comment /deploy-preview, from a repo user or github action bot (user id 41898282)
     if: >
       (
-        github.event_name == 'pull_request' && 
+        github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.fork != true
-      ) || 
+      ) ||
       (
-        github.event.issue.pull_request && 
+        github.event.issue.pull_request &&
         (
           github.event.comment.user.id == '41898282' ||
-          github.event.comment.author_association == 'MEMBER' || 
-          github.event.comment.author_association == 'OWNER' || 
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER' ||
           github.event.comment.author_association == 'COLLABORATOR'
-        ) && 
+        ) &&
         startsWith(github.event.comment.body, '/deploy-preview')
       )
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,7 +1,7 @@
 on:
   # workflow_dispatch allows deploy preview by pushing button on GitHub
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     branches: [main]
   issue_comment:
     types: [created]
@@ -12,7 +12,7 @@ jobs:
 
   is-external-pr:
     # Post a one-time comment on fork PRs reminding maintainers to trigger the deploy preview manually.
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true && github.event.action == 'opened' }}
+    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true && github.event.action == 'opened' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -46,7 +46,7 @@ jobs:
     # - requested by PR comment /deploy-preview, from a repo user or github action bot (user id 41898282)
     if: >
       (
-        github.event_name == 'pull_request' &&
+        github.event_name == 'pull_request_target' &&
         github.event.pull_request.head.repo.fork != true
       ) ||
       (


### PR DESCRIPTION
This will create a comment in the PR thread when a PR is opened from a fork, reminding repo maintainers to comment with `/deploy-preview` to trigger a deploy preview.